### PR TITLE
refactor(chains): centralize contract addresses under chain configs

### DIFF
--- a/src/actions/ens.ts
+++ b/src/actions/ens.ts
@@ -9,12 +9,7 @@ import { toHex } from 'ox/Signature'
 import { chains, isTTY } from '../constants.js'
 import { MissingCLIArgsError, MissingKeyError } from '../errors.js'
 import type { ChainName } from '../types.js'
-import {
-  chainToRpcUrl,
-  PUBLIC_RESOLVER_ADDRESS,
-  prepareUpdateEnsArgs,
-  setContentHash,
-} from '../utils/ens.js'
+import { chainToRpcUrl, prepareUpdateEnsArgs, setContentHash } from '../utils/ens.js'
 import { assertCID } from '../utils/ipfs.js'
 import { logger } from '../utils/logger.js'
 import { getNonce } from '../utils/safe/constants.js'
@@ -108,9 +103,10 @@ export const ensAction = async ({
 
   if (options.verbose) console.log('Transaction encoded data:', data)
 
-  const to = resolverAddress || PUBLIC_RESOLVER_ADDRESS[chainName]
+  const to =
+    resolverAddress || chains[chainName].contracts.publicResolver.address
 
-  if (to === PUBLIC_RESOLVER_ADDRESS[chainName] && !domain.endsWith('.eth'))
+  if (to === chains[chainName].contracts.publicResolver.address && !domain.endsWith('.eth'))
     throw new Error('Domain must end with .eth')
 
   if (safeAddress) {

--- a/src/actions/zodiac.ts
+++ b/src/actions/zodiac.ts
@@ -6,7 +6,6 @@ import type { Hex } from 'ox/Hex'
 import { getPublicKey, randomPrivateKey } from 'ox/Secp256k1'
 import { chains } from '../constants.js'
 import { MissingCLIArgsError } from '../errors.js'
-import { PUBLIC_RESOLVER_ADDRESS } from '../utils/ens.js'
 import { logger } from '../utils/logger.js'
 
 import {
@@ -29,7 +28,7 @@ export const zodiacAction = async ({
 
   const resolverAddress =
     options['resolver-address'] ??
-    PUBLIC_RESOLVER_ADDRESS[options.chain ?? 'mainnet']
+    chains[options.chain ?? 'mainnet'].contracts.publicResolver.address
 
   const safe = options.safe
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -135,6 +135,11 @@ export const chains = {
   mainnet: {
     id: 1,
     name: 'Ethereum',
+    contracts: {
+      publicResolver: {
+        address: '0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63',
+      },
+    },
     blockExplorers: {
       default: {
         name: 'Etherscan',
@@ -145,6 +150,11 @@ export const chains = {
   sepolia: {
     id: 11_155_111,
     name: 'Sepolia',
+    contracts: {
+      publicResolver: {
+        address: '0x8FADE66B79cC9f707aB26799354482EB93a5B7dD',
+      },
+    },
     blockExplorers: {
       default: {
         name: 'Etherscan',

--- a/src/utils/ens.ts
+++ b/src/utils/ens.ts
@@ -71,11 +71,6 @@ export const setContentHash = {
   outputs: [],
 } as const
 
-export const PUBLIC_RESOLVER_ADDRESS: Record<ChainName, Address> = {
-  mainnet: '0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63',
-  sepolia: '0x8FADE66B79cC9f707aB26799354482EB93a5B7dD',
-} as const
-
 export const chainToRpcUrl = (chain: ChainName) => {
   switch (chain) {
     case 'mainnet':

--- a/src/utils/filecoin/constants.ts
+++ b/src/utils/filecoin/constants.ts
@@ -6,17 +6,6 @@ export const filProvider = Provider.from(
   fromHttp('https://api.calibration.node.glif.io/rpc/v1'),
 )
 
-export const FWSS_KEEPER_ADDRESS = '0x02925630df557F957f70E112bA06e50965417CA0'
-
-export const FWSS_PROXY_ADDRESS = '0x839e5c9988e4e9977d40708d0094103c0839Ac9D'
-
-export const FWSS_REGISTRY_VIEW_ADDRESS =
-  '0xA5D87b04086B1d591026cCE10255351B5AA4689B'
-
-export const USDFC_ADDRESS = '0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0'
-
-export const FILECOIN_PAY_ADDRESS = '0x09a0fDc2723fAd1A7b8e3e00eE5DF73841df55a0'
-
 export type FilecoinChain = {
   id: number
   name: string
@@ -31,6 +20,12 @@ export type FilecoinChain = {
       address: Address
     }
     storage: {
+      address: Address
+    }
+    proxy: {
+      address: Address
+    }
+    registryView: {
       address: Address
     }
   }
@@ -54,6 +49,12 @@ export const filecoinCalibration: FilecoinChain = {
     },
     storage: {
       address: '0x02925630df557F957f70E112bA06e50965417CA0',
+    },
+    proxy: {
+      address: '0x839e5c9988e4e9977d40708d0094103c0839Ac9D',
+    },
+    registryView: {
+      address: '0xA5D87b04086B1d591026cCE10255351B5AA4689B',
     },
   },
   blockExplorers: {

--- a/src/utils/filecoin/createDataSet.ts
+++ b/src/utils/filecoin/createDataSet.ts
@@ -10,11 +10,7 @@ import * as Value from 'ox/Value'
 import { DeployError } from '../../errors.js'
 import { logger } from '../logger.js'
 import { waitForTransaction } from '../tx.js'
-import {
-  FWSS_KEEPER_ADDRESS,
-  filecoinCalibration,
-  filProvider,
-} from './constants.js'
+import { filecoinCalibration, filProvider } from './constants.js'
 import { depositAndApproveOperator } from './pay/depositAndApproveOperator.js'
 import { getAccountInfo } from './pay/getAccountInfo.js'
 
@@ -82,7 +78,7 @@ export const createDataSet = async ({
     },
     domain: {
       name: 'FilecoinWarmStorageService',
-      verifyingContract: FWSS_KEEPER_ADDRESS,
+      verifyingContract: filecoinCalibration.contracts.storage.address,
       version: '1',
       chainId: filecoinCalibration.id,
     },
@@ -103,14 +99,16 @@ export const createDataSet = async ({
     values,
     signature,
   ])
-  logger.info(`Record keeper address: ${FWSS_KEEPER_ADDRESS}`)
+  logger.info(
+    `Record keeper address: ${filecoinCalibration.contracts.storage.address}`,
+  )
 
   const res = await fetch(new URL('/pdp/data-sets', providerURL), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     redirect: 'follow',
     body: JSON.stringify({
-      recordKeeper: FWSS_KEEPER_ADDRESS,
+      recordKeeper: filecoinCalibration.contracts.storage.address,
       extraData,
     }),
   })

--- a/src/utils/filecoin/getApprovedSPs.ts
+++ b/src/utils/filecoin/getApprovedSPs.ts
@@ -1,5 +1,5 @@
 import { decodeResult, encodeData } from 'ox/AbiFunction'
-import { FWSS_REGISTRY_VIEW_ADDRESS, filProvider } from './constants.js'
+import { filecoinCalibration, filProvider } from './constants.js'
 
 const abi = [
   {
@@ -31,7 +31,7 @@ export const getApprovedSPs = async () => {
     params: [
       {
         data: lenData,
-        to: FWSS_REGISTRY_VIEW_ADDRESS,
+        to: filecoinCalibration.contracts.registryView.address,
       },
       'latest',
     ],
@@ -45,7 +45,7 @@ export const getApprovedSPs = async () => {
     params: [
       {
         data: listData,
-        to: FWSS_REGISTRY_VIEW_ADDRESS,
+        to: filecoinCalibration.contracts.registryView.address,
       },
       'latest',
     ],

--- a/src/utils/filecoin/getClientDatasets.ts
+++ b/src/utils/filecoin/getClientDatasets.ts
@@ -1,6 +1,6 @@
 import { decodeResult, encodeData } from 'ox/AbiFunction'
 import type { Address } from 'ox/Address'
-import { FWSS_REGISTRY_VIEW_ADDRESS, filProvider } from './constants.js'
+import { filecoinCalibration, filProvider } from './constants.js'
 
 const abi = {
   type: 'function',
@@ -92,7 +92,7 @@ export const getClientDataSets = async (address: Address) => {
     params: [
       {
         data,
-        to: FWSS_REGISTRY_VIEW_ADDRESS,
+        to: filecoinCalibration.contracts.registryView.address,
       },
       'latest',
     ],

--- a/src/utils/filecoin/getDataSet.ts
+++ b/src/utils/filecoin/getDataSet.ts
@@ -1,9 +1,5 @@
 import { decodeResult, encodeData } from 'ox/AbiFunction'
-import {
-  FWSS_REGISTRY_VIEW_ADDRESS,
-  filecoinCalibration,
-  filProvider,
-} from './constants.js'
+import { filecoinCalibration, filProvider } from './constants.js'
 
 const abi = {
   type: 'function',
@@ -36,7 +32,10 @@ export const getDataSet = async (dataSetId: bigint) => {
   const result = await filProvider.request({
     method: 'eth_call',
     params: [
-      { data: encodeData(abi, [dataSetId]), to: FWSS_REGISTRY_VIEW_ADDRESS },
+      {
+        data: encodeData(abi, [dataSetId]),
+        to: filecoinCalibration.contracts.registryView.address,
+      },
       'latest',
     ],
   })

--- a/src/utils/filecoin/getProviderIdByAddress.ts
+++ b/src/utils/filecoin/getProviderIdByAddress.ts
@@ -1,6 +1,6 @@
 import { decodeResult, encodeData } from 'ox/AbiFunction'
 import type { Address } from 'ox/Address'
-import { FWSS_PROXY_ADDRESS, filProvider } from './constants.js'
+import { filecoinCalibration, filProvider } from './constants.js'
 
 const abi = {
   type: 'function',
@@ -28,7 +28,7 @@ export const getProviderIdByAddress = async (
     params: [
       {
         data: encodeData(abi, [providerAddress]),
-        to: FWSS_PROXY_ADDRESS,
+        to: filecoinCalibration.contracts.proxy.address,
       },
       'latest',
     ],

--- a/src/utils/filecoin/getProviderPayee.ts
+++ b/src/utils/filecoin/getProviderPayee.ts
@@ -1,6 +1,6 @@
 import { decodeResult, encodeData } from 'ox/AbiFunction'
 import { type Address, checksum } from 'ox/Address'
-import { FWSS_PROXY_ADDRESS, filProvider } from './constants.js'
+import { filecoinCalibration, filProvider } from './constants.js'
 
 const abi = {
   type: 'function',
@@ -26,7 +26,7 @@ export const getProviderPayee = async (id: bigint): Promise<Address> => {
     params: [
       {
         data: encodeData(abi, [id]),
-        to: FWSS_PROXY_ADDRESS,
+        to: filecoinCalibration.contracts.proxy.address,
       },
       'latest',
     ],

--- a/src/utils/filecoin/getUSDfcBalance.ts
+++ b/src/utils/filecoin/getUSDfcBalance.ts
@@ -1,6 +1,6 @@
 import { decodeResult, encodeData } from 'ox/AbiFunction'
 import type { Address } from 'ox/Address'
-import { filProvider, USDFC_ADDRESS } from './constants.js'
+import { filecoinCalibration, filProvider } from './constants.js'
 
 const abi = {
   constant: true,
@@ -25,7 +25,13 @@ const abi = {
 export const getUSDfcBalance = async (address: Address) => {
   const result = await filProvider.request({
     method: 'eth_call',
-    params: [{ data: encodeData(abi, [address]), to: USDFC_ADDRESS }, 'latest'],
+    params: [
+      {
+        data: encodeData(abi, [address]),
+        to: filecoinCalibration.contracts.usdfc.address,
+      },
+      'latest',
+    ],
   })
 
   return decodeResult(abi, result)

--- a/src/utils/filecoin/pay/depositAndApproveOperator.ts
+++ b/src/utils/filecoin/pay/depositAndApproveOperator.ts
@@ -5,14 +5,7 @@ import { InternalError } from 'ox/RpcResponse'
 import { maxUint256 } from 'ox/Solidity'
 import { logger } from '../../logger.js'
 import { sendTransaction, simulateTransaction } from '../../tx.js'
-import {
-  FILECOIN_PAY_ADDRESS,
-  type FilecoinChain,
-  FWSS_KEEPER_ADDRESS,
-  filecoinCalibration,
-  filProvider,
-  USDFC_ADDRESS,
-} from '../constants.js'
+import { type FilecoinChain, filecoinCalibration, filProvider } from '../constants.js'
 import { getErc20WithPermitData } from './getErc20WithPermitData.js'
 import { signErc20Permit } from './signErc20Permit.js'
 

--- a/src/utils/filecoin/pay/getAccountInfo.ts
+++ b/src/utils/filecoin/pay/getAccountInfo.ts
@@ -1,10 +1,6 @@
 import { decodeResult, encodeData } from 'ox/AbiFunction'
 import type { Address } from 'ox/Address'
-import {
-  FILECOIN_PAY_ADDRESS,
-  filProvider,
-  USDFC_ADDRESS,
-} from '../constants.js'
+import { filecoinCalibration, filProvider } from '../constants.js'
 
 const abi = {
   type: 'function',
@@ -27,8 +23,8 @@ export const getAccountInfo = async (address: Address) => {
     method: 'eth_call',
     params: [
       {
-        data: encodeData(abi, [USDFC_ADDRESS, address]),
-        to: FILECOIN_PAY_ADDRESS,
+        data: encodeData(abi, [filecoinCalibration.contracts.usdfc.address, address]),
+        to: filecoinCalibration.contracts.payments.address,
       },
       'latest',
     ],

--- a/src/utils/filecoin/pay/signErc20Permit.ts
+++ b/src/utils/filecoin/pay/signErc20Permit.ts
@@ -2,11 +2,7 @@ import type { Address } from 'ox/Address'
 import type { Hex } from 'ox/Hex'
 import { sign } from 'ox/Secp256k1'
 import { getSignPayload } from 'ox/TypedData'
-import {
-  FILECOIN_PAY_ADDRESS,
-  filecoinCalibration,
-  USDFC_ADDRESS,
-} from '../constants.js'
+import { filecoinCalibration } from '../constants.js'
 
 export const signErc20Permit = async ({
   privateKey,
@@ -32,11 +28,11 @@ export const signErc20Permit = async ({
         chainId: filecoinCalibration.id,
         name,
         version,
-        verifyingContract: USDFC_ADDRESS,
+        verifyingContract: filecoinCalibration.contracts.usdfc.address,
       },
       message: {
         owner: address,
-        spender: FILECOIN_PAY_ADDRESS,
+        spender: filecoinCalibration.contracts.payments.address,
         value: amount,
         nonce,
         deadline,

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -12,6 +12,11 @@ describe('constants', () => {
               "url": "https://etherscan.io",
             },
           },
+          "contracts": {
+            "publicResolver": {
+              "address": "0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63",
+            },
+          },
           "id": 1,
           "name": "Ethereum",
         },
@@ -20,6 +25,11 @@ describe('constants', () => {
             "default": {
               "name": "Etherscan",
               "url": "https://sepolia.etherscan.io",
+            },
+          },
+          "contracts": {
+            "publicResolver": {
+              "address": "0x8FADE66B79cC9f707aB26799354482EB93a5B7dD",
             },
           },
           "id": 11155111,


### PR DESCRIPTION
- Summary
      - Move hardcoded contract addresses into chain-scoped configs.
      - ENS: add contracts.publicResolver.address to chains for mainnet and sepolia.
      - Filecoin: consolidate addresses under filecoinCalibration.contracts (multicall3, usdfc, payments, storage, proxy,
        registryView).
  - Implementation
      - Replace all usages of removed consts with reads from chain configs.
      - Remove PUBLIC_RESOLVER_ADDRESS from src/utils/ens.ts.
      - Update ENS actions to use chains[chainName].contracts.publicResolver.address.
      - Update Filecoin utils to use filecoinCalibration.contracts.*.
      - Adjust snapshot: test/constants.test.ts includes contracts.publicResolver.
  - Why
      - Avoid scattered hardcoded addresses; improve maintainability and multi-chain readiness.
      - Keep code look-and-feel similar while centralizing configuration.
  - Impact
      - CLI behavior unchanged; flags and outputs unaffected.
      - Internal-only API change: PUBLIC_RESOLVER_ADDRESS removed. If any external code imports it, switch to
        chains[chainName].contracts.publicResolver.address.
  - Testing
      - Typecheck passes: bun run types.
      - Build passes: bun run build.
      - Tests pass: bun test (1 snapshot updated).
  - Follow-ups
      - Add resolvers for additional Ethereum networks if needed.
      - If supporting more Filecoin networks, mirror the contracts structure for each chain.
      - Consider moving RPC URLs into chains to fully centralize network config.

 