### PR TITLE
fix: Filecoin calibration and dataset handling improvements

### DIFF
--- a/src/actions/deploy.ts
+++ b/src/actions/deploy.ts
@@ -1,6 +1,6 @@
 import { isTTY, PROVIDERS } from '../constants.js'
 import { AsciiBar, styleText } from '../deps.js'
-import { MissingKeyError, NoProvidersError } from '../errors.js'
+import { NoProvidersError } from '../errors.js'
 import {
   findEnvVarProviderName,
   parseTokensFromEnv,
@@ -149,9 +149,6 @@ export const deployAction = async ({
       const providerURL = apiTokens.get('FILECOIN_SP_URL'),
         providerAddress = apiTokens.get('FILECOIN_SP_ADDRESS'),
         pieceCid = apiTokens.get('FILECOIN_PIECE_CID')
-
-      if (filecoinChain && !providerURL)
-        throw new MissingKeyError('FILECOIN_SP_URL')
 
       try {
         await provider.upload({

--- a/src/providers/ipfs/filecoin.ts
+++ b/src/providers/ipfs/filecoin.ts
@@ -43,8 +43,6 @@ export const uploadToFilecoin: UploadFunction<{
   filecoinChain = 'mainnet',
   size,
 }) => {
-  if (!providerURL && providerAddress)
-    throw new MissingKeyError('FILECOIN_SP_URL')
   if (!providerAddress && providerURL)
     throw new MissingKeyError('FILECOIN_SP_ADDRESS')
 

--- a/src/providers/ipfs/filecoin.ts
+++ b/src/providers/ipfs/filecoin.ts
@@ -16,6 +16,7 @@ import { getClientDataSets } from '../../utils/filecoin/getClientDatasets.js'
 import { getProviderIdByAddress } from '../../utils/filecoin/getProviderIdByAddress.js'
 import { getProviderMetadata } from '../../utils/filecoin/getProviderMetadata.js'
 import { getProviderPayee } from '../../utils/filecoin/getProviderPayee.js'
+import { getRail } from '../../utils/filecoin/getRail.js'
 import { getRandomProviderId } from '../../utils/filecoin/getRandomProviderId.js'
 import { getUSDfcBalance } from '../../utils/filecoin/getUSDfcBalance.js'
 import { getServicePrice } from '../../utils/filecoin/pay/getServicePrice.js'
@@ -91,6 +92,31 @@ export const uploadToFilecoin: UploadFunction<{
     providerAddress = address
   }
 
+  const validateProviderURL = async (
+    url: string,
+    id: bigint,
+    attempt = 0,
+  ): Promise<{ url: string; id: bigint }> => {
+    try {
+      await fetch(url, { method: 'HEAD' })
+      return { url, id }
+    } catch (_e) {
+      if (attempt >= 5) throw new Error(`No reachable SP found`)
+      logger.warn(`SP URL ${url} not reachable, trying another provider...`)
+      const newProviderId = await getRandomProviderId({ chain })
+      const { serviceURL, address } = await getProviderMetadata({
+        chain,
+        providerId: newProviderId,
+      })
+      providerAddress = address
+      return validateProviderURL(serviceURL, newProviderId, attempt + 1)
+    }
+  }
+
+  const validated = await validateProviderURL(providerURL, providerId)
+  providerURL = validated.url
+  providerId = validated.id
+
   const payee = await getProviderPayee({ id: providerId, chain })
 
   if (verbose) logger.info(`Filecoin SP Payee: ${payee}`)
@@ -105,8 +131,31 @@ export const uploadToFilecoin: UploadFunction<{
     (set) => set.providerId === providerId,
   )
 
-  if (providerDataSets.length === 0) {
-    if (verbose) logger.info('No dataset found. Creating.')
+  const findActiveDataset = async () => {
+    for (const ds of providerDataSets) {
+      try {
+        const rail = await getRail({ railId: ds.pdpRailId, chain })
+        if (rail.endEpoch === 0n) {
+          return ds
+        }
+        logger.info(
+          `Dataset ${ds.dataSetId} is terminated (endEpoch: ${rail.endEpoch}), checking next...`,
+        )
+      } catch {
+        // If we can't fetch rail info, we can't verify if it's active or not
+        // Don't return it - just continue to the next dataset
+        logger.warn(
+          `Could not fetch rail info for dataset ${ds.dataSetId}, skipping`,
+        )
+      }
+    }
+    return null
+  }
+
+  const activeDataset = await findActiveDataset()
+
+  if (!activeDataset) {
+    if (verbose) logger.info('No active dataset found. Creating new.')
     const {
       clientDataSetId: clientId,
       hash,
@@ -129,11 +178,24 @@ export const uploadToFilecoin: UploadFunction<{
     await waitForDatasetReady(statusUrl)
 
     logger.success('Data set registered')
+
+    const newDataSets = await getClientDataSets({ address, chain })
+    const newDataset = newDataSets.find((ds) => ds.clientDataSetId === clientId)
+    if (!newDataset) {
+      throw new DeployError(
+        providerName,
+        'Failed to find newly created dataset',
+      )
+    }
+    datasetId = newDataset.dataSetId
+    clientDataSetId = clientId
+
+    logger.info(`SP Dataset ID: ${datasetId}`)
     logger.info('Waiting for 5 seconds to ensure everything is in sync')
     await setTimeout(5000)
   } else {
-    logger.info(`Using existing dataset: ${providerDataSets[0].dataSetId}`)
-    datasetId = providerDataSets[0].dataSetId
+    logger.info(`Using active dataset: ${activeDataset.dataSetId}`)
+    datasetId = activeDataset.dataSetId
   }
 
   // Buffer CAR bytes once and derive Piece CID
@@ -219,16 +281,83 @@ export const uploadToFilecoin: UploadFunction<{
   }
   logger.success('Piece found')
 
-  const { hash, statusUrl } = await uploadPieceToDataSet({
-    pieceCid: calculatedCid,
-    providerURL,
-    verbose,
-    datasetId,
-    privateKey,
-    nonce: BigInt(randomInt(10 ** 8)),
-    clientDataSetId,
-    chain,
-  })
+  const tryUploadPiece = async (): Promise<{
+    hash: Hex
+    statusUrl: string
+  }> => {
+    try {
+      return await uploadPieceToDataSet({
+        pieceCid: calculatedCid,
+        providerURL,
+        verbose,
+        datasetId,
+        privateKey,
+        nonce: BigInt(randomInt(10 ** 8)),
+        clientDataSetId,
+        chain,
+      })
+    } catch (e) {
+      const error = e as Error
+      const cause = error.cause as string | undefined
+
+      if (
+        cause?.includes('0x211a40c0') ||
+        error.message.includes('DataSetPaymentAlreadyTerminated')
+      ) {
+        logger.warn('Dataset payment terminated. Creating new dataset...')
+        const {
+          clientDataSetId: newClientId,
+          hash,
+          statusUrl,
+        } = await createDataSet({
+          privateKey,
+          payee,
+          providerURL,
+          address,
+          chain,
+          perMonth,
+        })
+
+        logger.info(`Pending data set creation: ${statusUrl}`)
+        logger.info(`Pending transaction: ${chain.blockExplorer}/tx/${hash}`)
+        await waitForTransaction(filProvider[chainId], hash)
+
+        await waitForDatasetReady(statusUrl)
+
+        logger.success('New data set registered')
+
+        const newDataSets = await getClientDataSets({ address, chain })
+        const newDataset = newDataSets.find(
+          (ds) => ds.clientDataSetId === newClientId,
+        )
+        if (!newDataset) {
+          throw new DeployError(
+            providerName,
+            'Failed to find newly created dataset',
+          )
+        }
+        const newDatasetId = newDataset.dataSetId
+        logger.info(`SP Dataset ID: ${newDatasetId}`)
+        logger.info('Waiting for 5 seconds to ensure everything is in sync')
+        await setTimeout(5000)
+
+        return uploadPieceToDataSet({
+          pieceCid: calculatedCid,
+          providerURL,
+          verbose,
+          datasetId: newDatasetId, // SP's dataset ID
+          privateKey,
+          nonce: BigInt(randomInt(10 ** 8)),
+          clientDataSetId: newClientId, // Client's dataset ID
+          chain,
+        })
+      }
+
+      throw e
+    }
+  }
+
+  const { hash, statusUrl } = await tryUploadPiece()
   logger.info(`Pending piece upload: ${statusUrl}`)
   logger.info(`Pending transaction: ${chain.blockExplorer}/tx/${hash}`)
   await waitForTransaction(filProvider[chainId], hash)

--- a/src/utils/filecoin/createDataSet.ts
+++ b/src/utils/filecoin/createDataSet.ts
@@ -13,6 +13,7 @@ import { waitForTransaction } from '../tx.js'
 import { type FilecoinChain, filProvider } from './constants.js'
 import { depositAndApproveOperator } from './pay/depositAndApproveOperator.js'
 import { getAccountInfo } from './pay/getAccountInfo.js'
+import { getErc20WithPermitData } from './pay/getErc20WithPermitData.js'
 
 const abi = ['address', 'uint256', 'string[]', 'string[]', 'bytes'] as const
 
@@ -20,8 +21,6 @@ const metadata = [{ key: 'withIPFSIndexing', value: '' }] as const
 
 const keys = metadata.map((item) => item.key)
 const values = metadata.map((item) => item.value)
-
-const priceBuffer = Value.from('0.5', 18)
 
 /**
  * Create a data set on an SP, and deposit to Filecoin Pay if balanace is 0
@@ -45,16 +44,35 @@ export const createDataSet = async ({
   perMonth: bigint
 }) => {
   const provider = filProvider[chain.id]
-  const [funds] = await getAccountInfo({ address: payer, chain })
+  const [accountInfo, lockupCurrent] = await getAccountInfo({
+    address: payer,
+    chain,
+  })
+  const [walletBalance] = await getErc20WithPermitData({
+    address: payer,
+    chain,
+  })
+
+  const funds = accountInfo
 
   logger.info(`Deposited funds: ${Value.format(funds, 18)}`)
+  logger.info(`Lockup current: ${Value.format(lockupCurrent, 18)}`)
 
-  if (funds <= perMonth + priceBuffer) {
-    const depositAmount = perMonth - funds + priceBuffer // $0.5 buffer to avoid "Insufficient funds" errors
+  const minLockup = perMonth
+  const needed = minLockup + perMonth
+  if (funds <= minLockup) {
+    const depositAmount = needed - funds
     logger.warn('Not enough USDfc deposited to Filecoin Pay')
     logger.info(
       `Depositing ${Value.format(depositAmount, 18)} USDfc to Filecoin Pay`,
     )
+
+    if (walletBalance < depositAmount) {
+      throw new DeployError(
+        'Filecoin',
+        `Insufficient USDfc in wallet. Have: ${Value.format(walletBalance, 18)}, need: ${Value.format(depositAmount, 18)}`,
+      )
+    }
 
     const hash = await depositAndApproveOperator({
       privateKey,

--- a/src/utils/filecoin/getRail.ts
+++ b/src/utils/filecoin/getRail.ts
@@ -1,0 +1,63 @@
+import { decodeResult, encodeData } from 'ox/AbiFunction'
+import { type FilecoinChain, filProvider } from './constants.js'
+
+const abi = {
+  type: 'function',
+  name: 'getRail',
+  inputs: [{ name: 'railId', type: 'uint256', internalType: 'uint256' }],
+  outputs: [
+    {
+      name: '',
+      type: 'tuple',
+      components: [
+        { name: 'token', type: 'address', internalType: 'address' },
+        { name: 'from', type: 'address', internalType: 'address' },
+        { name: 'to', type: 'address', internalType: 'address' },
+        { name: 'operator', type: 'address', internalType: 'address' },
+        { name: 'validator', type: 'address', internalType: 'address' },
+        { name: 'paymentRate', type: 'uint256', internalType: 'uint256' },
+        { name: 'lockupPeriod', type: 'uint256', internalType: 'uint256' },
+        { name: 'lockupFixed', type: 'uint256', internalType: 'uint256' },
+        { name: 'settledUpTo', type: 'uint256', internalType: 'uint256' },
+        { name: 'endEpoch', type: 'uint256', internalType: 'uint256' },
+        { name: 'commissionRateBps', type: 'uint256', internalType: 'uint256' },
+        {
+          name: 'serviceFeeRecipient',
+          type: 'address',
+          internalType: 'address',
+        },
+      ],
+    },
+  ],
+  stateMutability: 'view',
+} as const
+
+export type RailInfo = Awaited<ReturnType<typeof getRail>>
+
+/**
+ * Get rail info by ID
+ * @returns Rail info including endEpoch - if > 0, rail is terminated
+ */
+export const getRail = async ({
+  railId,
+  chain,
+}: {
+  railId: bigint
+  chain: FilecoinChain
+}) => {
+  const data = encodeData(abi, [railId])
+  const provider = filProvider[chain.id]
+
+  const result = await provider.request({
+    method: 'eth_call',
+    params: [
+      {
+        data,
+        to: chain.contracts.payments.address,
+      },
+      'latest',
+    ],
+  })
+
+  return decodeResult(abi, result)
+}


### PR DESCRIPTION
This PR includes several fixes for the Filecoin provider:

1. Fixes Filecoin calibration/mainnet to work without explicit SP URL by removing premature error checks
2. Adds proactive dataset validation to check if existing datasets are terminated before using them
3. Fixes dataset ID handling when creating new datasets (using correct SP dataset ID vs client dataset ID)
4. Adds wallet balance checking to prevent insufficient funds errors
5. Adds SP URL validation to avoid using unreachable storage providers
6. Removes the 0.5 USDfc buffer in createDataSet for more precise deposits

These changes should resolve the "OMNIPIN_FILECOIN_SP_URL is missing" error and improve reliability when dealing with terminated dataset payment rails.
