### PR TITLE
Fix filecoin OOM

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@biomejs/biome": "^2.4.7",
         "@ipld/car": "^5.4.2",
         "@ipld/dag-ucan": "^3.4.5",
-        "@omnipin/foc": "npm:@jsr/omnipin__foc@0.0.10",
+        "@omnipin/foc": "npm:@jsr/omnipin__foc@0.0.11",
         "@rslib/core": "^0.20.0",
         "@size-limit/file": "^12.0.1",
         "@stauro/filebase-upload": "npm:@jsr/stauro__filebase-upload",
@@ -224,7 +224,7 @@
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
-    "@omnipin/foc": ["@jsr/omnipin__foc@0.0.10", "https://npm.jsr.io/~/11/@jsr/omnipin__foc/0.0.10.tgz", { "dependencies": { "@noble/hashes": "^2.0.1", "multiformats": "^13.4.2", "ox": "^0.14.8", "varint": "^6.0.0" } }, "sha512-RXSrzbLyJEvHnCMCqu7hrdQSIl6zO2SuZ88KVBWQ3eeyzR92pgDInziCguVJj4y5//g/fDxeshXWlvOSVP2Clg=="],
+    "@omnipin/foc": ["@jsr/omnipin__foc@0.0.11", "https://npm.jsr.io/~/11/@jsr/omnipin__foc/0.0.11.tgz", { "dependencies": { "@noble/hashes": "^2.0.1", "multiformats": "^13.4.2", "ox": "^0.14.8", "varint": "^6.0.0" } }, "sha512-ow8klaAdUMqonihyWLsdI1E50Jvm2hRMlaDuaHzwTcHu1ruoXlX+3aOh/E9uSJHGuL4bNHvAKVmOBU2NLqFFkg=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.57.1", "", { "os": "android", "cpu": "arm" }, "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@biomejs/biome": "^2.4.7",
     "@ipld/car": "^5.4.2",
     "@ipld/dag-ucan": "^3.4.5",
-    "@omnipin/foc": "npm:@jsr/omnipin__foc@0.0.10",
+    "@omnipin/foc": "npm:@jsr/omnipin__foc@0.0.11",
     "@rslib/core": "^0.20.0",
     "@size-limit/file": "^12.0.1",
     "@stauro/filebase-upload": "npm:@jsr/stauro__filebase-upload",

--- a/src/actions/deploy.ts
+++ b/src/actions/deploy.ts
@@ -80,7 +80,7 @@ export const deployAction = async ({
   const {
     name,
     cid: ipfsCid,
-    blob,
+    bytes,
     size,
   } = await packAction({
     dir,
@@ -117,7 +117,7 @@ export const deployAction = async ({
       const envVar = findEnvVarProviderName(provider.name)!
       try {
         const result = await provider.upload({
-          car: blob,
+          bytes,
           token: apiTokens.get(envVar)!,
           verbose,
           name: '',
@@ -155,7 +155,7 @@ export const deployAction = async ({
       try {
         await provider.upload({
           name,
-          car: blob,
+          bytes,
           token,
           bucketName,
           proof: apiTokens.get('STORACHA_PROOF'),

--- a/src/actions/pack.ts
+++ b/src/actions/pack.ts
@@ -49,10 +49,9 @@ export const packAction = async ({
 
   if (tar) {
     const tar = await packTAR(files)
-    const blob = new Blob([tar as BlobPart])
-    return { blob, size }
+    return { bytes: tar, size }
   } else {
-    const { rootCID, blob } = await packCAR(files, name, dist)
+    const { rootCID, bytes } = await packCAR(files, name, dist)
 
     const cid = rootCID.toString()
     if (onlyHash) {
@@ -61,6 +60,6 @@ export const packAction = async ({
       logger.info(`Root CID: ${isTTY ? styleText('white', cid) : cid}`)
     }
 
-    return { name, cid, blob, files, size }
+    return { name, cid, bytes, files, size }
   }
 }

--- a/src/providers/ipfs/filebase.ts
+++ b/src/providers/ipfs/filebase.ts
@@ -9,12 +9,13 @@ const baseURL = 'https://rpc.filebase.io/api/v0'
 
 export const uploadOnFilebase: UploadFunction<{ bucketName: string }> = async ({
   first,
-  car,
+  bytes,
   name,
   token,
   bucketName,
   verbose,
   cid,
+  size,
 }) => {
   if (first) {
     if (!bucketName) throw new MissingKeyError(`FILEBASE_BUCKET_NAME`)
@@ -25,8 +26,8 @@ export const uploadOnFilebase: UploadFunction<{ bucketName: string }> = async ({
       providerName,
       verbose,
       name,
-      car,
-      size: car.size,
+      bytes,
+      size,
       token,
     })
 

--- a/src/providers/ipfs/filecoin.ts
+++ b/src/providers/ipfs/filecoin.ts
@@ -79,7 +79,7 @@ export const uploadToFilecoin: UploadFunction<{
   providerAddress,
   providerURL,
   cid,
-  car,
+  bytes,
   token: privateKey,
   verbose,
   filecoinChain = 'mainnet',
@@ -130,7 +130,7 @@ export const uploadToFilecoin: UploadFunction<{
   logger.info(`Price for storage: ${Value.format(perMonth, 18)} USDfc/month`)
 
   // Buffer CAR bytes once and derive Piece CID
-  const carBytes = new Uint8Array(await car.arrayBuffer())
+  const carBytes = bytes
   const pieceCid = calculatePieceCID(carBytes)
 
   const datasets = await getClientDataSets({

--- a/src/providers/ipfs/lighthouse.ts
+++ b/src/providers/ipfs/lighthouse.ts
@@ -5,7 +5,7 @@ import { logger } from '../../utils/logger.js'
 const providerName = 'Lighthouse'
 
 export const uploadOnLighthouse: UploadFunction = async ({
-  car,
+  bytes,
   name,
   first,
   token,
@@ -15,7 +15,13 @@ export const uploadOnLighthouse: UploadFunction = async ({
   if (first) {
     const fd = new FormData()
 
-    fd.append('file', car, `${name}.car`)
+    fd.append(
+      'file',
+      new Blob([Uint8Array.from(bytes).buffer], {
+        type: 'application/vnd.ipld.car',
+      }),
+      `${name}.car`,
+    )
 
     const res = await fetch(
       'https://upload.lighthouse.storage/api/v0/dag/import',

--- a/src/providers/ipfs/pinata.ts
+++ b/src/providers/ipfs/pinata.ts
@@ -10,7 +10,7 @@ export const statusOnPinata: StatusFunction = (args) => {
 }
 
 export const uploadOnPinata: UploadFunction = async ({
-  car,
+  bytes,
   name,
   token,
   verbose,
@@ -20,7 +20,12 @@ export const uploadOnPinata: UploadFunction = async ({
   if (first) {
     const fd = new FormData()
 
-    fd.append('file', car)
+    fd.append(
+      'file',
+      new Blob([bytes.buffer as ArrayBuffer], {
+        type: 'application/vnd.ipld.car',
+      }),
+    )
     fd.append('network', 'public')
 
     fd.append('name', `${name}.car`)

--- a/src/providers/ipfs/s3.ts
+++ b/src/providers/ipfs/s3.ts
@@ -5,7 +5,7 @@ import { logger } from '../../utils/logger.js'
 
 export const uploadOnS3 = async ({
   name,
-  car,
+  bytes,
   token,
   bucketName,
   apiUrl,
@@ -19,7 +19,9 @@ export const uploadOnS3 = async ({
   }>,
   'first' | 'cid'
 >): Promise<Response> => {
-  const file = new File([car], name)
+  const file = new File([bytes.buffer as ArrayBuffer], name, {
+    type: 'application/vnd.ipld.car',
+  })
 
   const res = await uploadCar({ apiUrl, file, token, bucketName })
 

--- a/src/providers/ipfs/simplepage.ts
+++ b/src/providers/ipfs/simplepage.ts
@@ -5,13 +5,13 @@ const providerName = 'SimplePage'
 
 export const uploadToSimplePage: UploadFunction = async ({
   token,
-  car,
+  bytes,
   name,
 }) => {
   const fd = new FormData()
   fd.append(
     'file',
-    new File([car], `${name}.car`, {
+    new File([bytes.buffer as ArrayBuffer], `${name}.car`, {
       type: 'application/vnd.ipld.car',
     }),
   )

--- a/src/providers/ipfs/storacha.ts
+++ b/src/providers/ipfs/storacha.ts
@@ -19,7 +19,7 @@ const abilities = [
 
 export const uploadOnStoracha: UploadFunction<{ proof: string }> = async ({
   token,
-  car,
+  bytes,
   proof,
 }) => {
   if (!proof) throw new MissingKeyError(`STORACHA_PROOF`)
@@ -27,6 +27,10 @@ export const uploadOnStoracha: UploadFunction<{ proof: string }> = async ({
   const { agent, space } = await setup({ pk: token, proof })
 
   if (!space) throw new Error('No space found')
+
+  const blob = new Blob([bytes.buffer as ArrayBuffer], {
+    type: 'application/vnd.ipld.car',
+  })
 
   try {
     const cid = await uploadCAR(
@@ -37,7 +41,7 @@ export const uploadOnStoracha: UploadFunction<{ proof: string }> = async ({
         ),
         with: space.did(),
       },
-      car,
+      blob,
     )
 
     return { cid: cid.toString() }

--- a/src/providers/swarm/bee.ts
+++ b/src/providers/swarm/bee.ts
@@ -7,14 +7,14 @@ const providerName = 'Bee'
 
 export const uploadOnBee: UploadFunction<{ beeURL: string }> = async ({
   token,
-  car,
+  bytes,
   verbose,
   beeURL,
   first,
 }) => {
   if (!first) throw new PinningNotSupportedError(providerName)
   const res = await fetch(`${beeURL}/bzz`, {
-    body: car,
+    body: new Blob([bytes.buffer as ArrayBuffer]),
     headers: {
       'Swarm-Postage-Batch-Id': token,
       'Content-Type': 'application/x-tar',

--- a/src/providers/swarm/swarmy.ts
+++ b/src/providers/swarm/swarmy.ts
@@ -7,13 +7,13 @@ const providerName = 'Swarmy'
 
 export const uploadOnSwarmy: UploadFunction = async ({
   token,
-  car,
+  bytes,
   verbose,
   first,
 }) => {
   if (!first) throw new PinningNotSupportedError(providerName)
   const body = new FormData()
-  body.append('file', car)
+  body.append('file', new Blob([bytes.buffer as ArrayBuffer]))
   const res = await fetch('https://api.swarmy.cloud/api/files?website=true', {
     body,
     headers: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ type AuthArgs = {
 export type UploadArgs<T = object> = {
   name: string
   verbose?: boolean
-  car: Blob
+  bytes: Uint8Array
   first: boolean
   size: number
   cid: string

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -29,7 +29,7 @@ export const packCAR = async (
   files: FileCandidate[],
   name: string,
   dir = tmp,
-): Promise<{ blob: Blob; rootCID: CID }> => {
+): Promise<{ bytes: Uint8Array; rootCID: CID }> => {
   const output = `${dir}/${name}.car`
 
   const blockstore = new MemoryBlockstore()
@@ -76,11 +76,9 @@ export const packCAR = async (
   await new Promise<void>((resolve) => writeStream.on('close', resolve))
 
   const file = await readFile(output)
-  const blob = new Blob([file as BlobPart], {
-    type: 'application/vnd.ipld.car',
-  })
+  const bytes = file as Uint8Array
 
-  return { blob, rootCID }
+  return { bytes, rootCID }
 }
 
 export const assertCID = (cid: string) => {

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -78,6 +78,8 @@ export const packCAR = async (
   const file = await readFile(output)
   const bytes = file as Uint8Array
 
+  blockstore.clear()
+
   return { bytes, rootCID }
 }
 

--- a/src/utils/ipfs/blockstore.ts
+++ b/src/utils/ipfs/blockstore.ts
@@ -114,6 +114,10 @@ export class MemoryBlockstore implements Blockstore {
     this.data.delete(base32.encode(key.multihash.bytes))
   }
 
+  clear(): void {
+    this.data.clear()
+  }
+
   *getAll(options?: AbortOptions): AwaitGenerator<Pair> {
     options?.signal?.throwIfAborted()
 

--- a/test/providers/filecoin.test.ts
+++ b/test/providers/filecoin.test.ts
@@ -7,8 +7,7 @@ import { uploadToFilecoin } from '../../src/providers/ipfs/filecoin.js'
 const [size, files] = await walk('./dist', false)
 const car = await packCAR(files, 'test.car')
 
-const carBytes = new Uint8Array(await car.blob.arrayBuffer())
-const _pieceCid = calculatePieceCID(carBytes).toString()
+const _pieceCid = calculatePieceCID(car.bytes).toString()
 
 describe('Filecoin', () => {
   it('should not throw MissingKeyError when only providerAddress is specified', async () => {
@@ -18,7 +17,7 @@ describe('Filecoin', () => {
     // testing as first provider, not because of missing env vars
     try {
       await uploadToFilecoin({
-        car: car.blob,
+        bytes: car.bytes,
         cid: car.rootCID.toString(),
         size,
         first: true, // This should trigger UploadNotSupportedError
@@ -49,7 +48,7 @@ describe('Filecoin', () => {
   it('throws if no USDfc on account', async () => {
     try {
       await uploadToFilecoin({
-        car: car.blob,
+        bytes: car.bytes,
         cid: car.rootCID.toString(),
         size,
         first: true,

--- a/test/providers/lighthouse.test.ts
+++ b/test/providers/lighthouse.test.ts
@@ -40,7 +40,7 @@ describe('Lighthouse', () => {
         cid,
         name: 'Omnipin test',
         first: false,
-        car: new Blob(),
+        bytes: new Uint8Array(),
         size: 0,
       })
 

--- a/test/providers/s3.test.ts
+++ b/test/providers/s3.test.ts
@@ -14,7 +14,7 @@ describe('s3', () => {
     })
     const res = await uploadOnS3({
       name: 'test.car',
-      car: new Blob([]),
+      bytes: new Uint8Array(),
       token: 'token',
       bucketName: 'bucketName',
       apiUrl: 'https://example.com',
@@ -33,7 +33,7 @@ describe('s3', () => {
     expect(
       uploadOnS3({
         name: 'test.car',
-        car: new Blob([]),
+        bytes: new Uint8Array(),
         token: 'token',
         bucketName: 'bucketName',
         apiUrl: 'https://example.com',

--- a/test/providers/storacha.test.ts
+++ b/test/providers/storacha.test.ts
@@ -31,7 +31,7 @@ describe('Storacha provider', () => {
           token,
           name: 'test',
           first: true,
-          car: car.blob,
+          bytes: car.bytes,
           cid: car.rootCID.toString(),
           size,
         })

--- a/test/utils/ipfs.test.ts
+++ b/test/utils/ipfs.test.ts
@@ -6,7 +6,7 @@ const te = new TextEncoder()
 
 describe('ipfs utils', () => {
   describe('packCAR', () => {
-    it('should pack files into a CAR and return blob and rootCID', async () => {
+    it('should pack files into a CAR and return bytes and rootCID', async () => {
       const files = [
         {
           path: 'a.txt',
@@ -22,11 +22,9 @@ describe('ipfs utils', () => {
         },
       ]
 
-      const { blob, rootCID } = await packCAR(files, 'test-car')
+      const { bytes, rootCID } = await packCAR(files, 'test-car')
 
-      assert.ok(blob instanceof Blob)
-      assert.strictEqual(blob.type, 'application/vnd.ipld.car')
-      assert.equal(blob.size, 468)
+      assert.ok(bytes instanceof Uint8Array)
       assert.ok(rootCID)
       assert.ok(rootCID.toString().startsWith('bafy'))
     })


### PR DESCRIPTION
- Bump foc with a memory-optimized `calculatePieceCID`
- Replace `Blob` with bytes to avoid copying of large Uint8Array buffers