### PR TITLE
fix: align Filecoin auto top-up with creation lockup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@biomejs/biome": "^2.4.7",
         "@ipld/car": "^5.4.2",
         "@ipld/dag-ucan": "^3.4.5",
-        "@omnipin/foc": "npm:@jsr/omnipin__foc@0.0.11",
+        "@omnipin/foc": "npm:@jsr/omnipin__foc@0.0.12",
         "@rslib/core": "^0.20.0",
         "@size-limit/file": "^12.0.1",
         "@stauro/filebase-upload": "npm:@jsr/stauro__filebase-upload",
@@ -224,7 +224,7 @@
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
-    "@omnipin/foc": ["@jsr/omnipin__foc@0.0.11", "https://npm.jsr.io/~/11/@jsr/omnipin__foc/0.0.11.tgz", { "dependencies": { "@noble/hashes": "^2.0.1", "multiformats": "^13.4.2", "ox": "^0.14.8", "varint": "^6.0.0" } }, "sha512-ow8klaAdUMqonihyWLsdI1E50Jvm2hRMlaDuaHzwTcHu1ruoXlX+3aOh/E9uSJHGuL4bNHvAKVmOBU2NLqFFkg=="],
+    "@omnipin/foc": ["@jsr/omnipin__foc@0.0.12", "https://npm.jsr.io/~/11/@jsr/omnipin__foc/0.0.12.tgz", { "dependencies": { "@noble/hashes": "^2.0.1", "multiformats": "^13.4.2", "ox": "^0.14.8", "varint": "^6.0.0" } }, "sha512-jzs7ZlwcokzdGnIJ5w7G8pB+wuqE77ZHun96QHUAGvLxWOyFNXOg05Zr1L1wbRLbhY10l1aWL1/f7fckYtolNQ=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.57.1", "", { "os": "android", "cpu": "arm" }, "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@biomejs/biome": "^2.4.7",
     "@ipld/car": "^5.4.2",
     "@ipld/dag-ucan": "^3.4.5",
-    "@omnipin/foc": "npm:@jsr/omnipin__foc@0.0.11",
+    "@omnipin/foc": "npm:@jsr/omnipin__foc@0.0.12",
     "@rslib/core": "^0.20.0",
     "@size-limit/file": "^12.0.1",
     "@stauro/filebase-upload": "npm:@jsr/stauro__filebase-upload",

--- a/src/providers/ipfs/filecoin.ts
+++ b/src/providers/ipfs/filecoin.ts
@@ -5,7 +5,8 @@ import {
 } from '@omnipin/foc/data-set'
 import {
   depositAndApproveOperatorWriteParameters,
-  getAccountInfo,
+  getAvailableFunds,
+  getDataSetCreationRequirements,
   getServicePrice,
   getUSDfcBalance,
 } from '@omnipin/foc/fil-pay'
@@ -41,8 +42,6 @@ import {
 } from '../../utils/tx.js'
 
 const providerName = 'Filecoin'
-
-const SYBIL_FEE = 100_000_000_000_000_000n
 
 async function findPiece(
   providerURL: string,
@@ -101,7 +100,7 @@ export const uploadToFilecoin: UploadFunction<{
     logger.info(`Payer address: ${address}`)
     logger.info(`Filecoin chain: ${chain.name}`)
 
-    logger.info(`USDfc balance: ${Value.format(balance, 18)}`)
+    logger.info(`Wallet USDfc balance: ${Value.format(balance, 18)}`)
     logger.info('Looking up existing data sets')
   }
 
@@ -144,31 +143,37 @@ export const uploadToFilecoin: UploadFunction<{
 
   const isNewDataSet =
     providerActiveDataSets.length === 0 || filecoinForceNewDataset
-  const sybilFee = isNewDataSet ? SYBIL_FEE : 0n
-  const totalRequired = perMonth + sybilFee
+  const creationRequirement = isNewDataSet
+    ? (await getDataSetCreationRequirements({ chain })).creationRequirement
+    : 0n
+  const requiredAmount =
+    isNewDataSet && creationRequirement > perMonth
+      ? creationRequirement
+      : perMonth
 
   if (verbose) {
-    logger.info(`Required lockup: ${Value.format(perMonth, 18)} USDFC`)
+    logger.info(`Storage price: ${Value.format(perMonth, 18)} USDFC/month`)
     if (isNewDataSet) {
-      logger.info(`Sybil fee: ${Value.format(sybilFee, 18)} USDFC`)
+      logger.info(
+        `Creation requirement: ${Value.format(creationRequirement, 18)} USDFC`,
+      )
     }
-    logger.info(`Total required: ${Value.format(totalRequired, 18)} USDFC`)
+    logger.info(`Required funds: ${Value.format(requiredAmount, 18)} USDFC`)
   }
 
-  const [funds, lockupCurrent, lockupRate, lockupLastSettledAt] =
-    await getAccountInfo({ address, chain })
-  const currentEpochHex = await filProvider[chain.id].request({
-    method: 'eth_blockNumber',
-  })
-  const currentEpoch = BigInt(currentEpochHex)
-  const epochSinceSettlement = currentEpoch - lockupLastSettledAt
-  const actualLockup = lockupCurrent + epochSinceSettlement * lockupRate
-  const availableFunds = funds > actualLockup ? funds - actualLockup : 0n
+  const { funds, availableFunds } = await getAvailableFunds({ address, chain })
 
-  logger.info(`Available funds: ${Value.format(availableFunds, 18)} USDFC`)
+  if (verbose) {
+    logger.info(
+      `Filecoin Pay deposited funds: ${Value.format(funds, 18)} USDFC`,
+    )
+  }
+  logger.info(
+    `Filecoin Pay available funds: ${Value.format(availableFunds, 18)} USDFC`,
+  )
 
   const depositNeeded =
-    totalRequired > availableFunds ? totalRequired - availableFunds : 0n
+    requiredAmount > availableFunds ? requiredAmount - availableFunds : 0n
 
   if (depositNeeded > 0n) {
     if (verbose)


### PR DESCRIPTION
## Summary
- update the Filecoin provider to use the new `@omnipin/foc` helpers for dataset creation requirements and available Filecoin Pay funds
- fund new datasets using `max(perMonth, creationRequirement)` so auto top-up matches the on-chain creation gate
- clarify verbose logging by separating wallet USDfc balance from Filecoin Pay deposited and available funds

## Validation
- `fish -lc 'envsource docs/.env; and bun src/cli.ts deploy --providers=Filecoin docs/.vitepress/dist --verbose --filecoin-chain=calibration'`
- deploy completed successfully on calibration using an existing dataset after depositing the required Filecoin Pay funds

## Notes
- `bun run types` currently fails due to pre-existing issues in the bumped `@omnipin/foc` package import paths and an unrelated local type resolution error outside this change
- `bun run check` reports existing repository warnings unrelated to this PR