### PR TITLE
fix(swarm): base32-encode CID instead of stringifying raw bytes

### DIFF
--- a/src/providers/swarm/bee.ts
+++ b/src/providers/swarm/bee.ts
@@ -1,7 +1,7 @@
 import { DeployError, PinningNotSupportedError } from '../../errors.js'
 import type { UploadFunction } from '../../types.js'
 import { logger } from '../../utils/logger.js'
-import { referenceToCID } from '../../utils/swarm.js'
+import { referenceToCIDString } from '../../utils/swarm.js'
 
 const providerName = 'Bee'
 
@@ -34,7 +34,7 @@ export const uploadOnBee: UploadFunction<{ beeURL: string }> = async ({
   }
 
   return {
-    cid: referenceToCID(`0x${json.reference}`).toString(),
+    cid: referenceToCIDString(`0x${json.reference}`),
     rID: json.reference,
   }
 }

--- a/src/providers/swarm/swarmy.ts
+++ b/src/providers/swarm/swarmy.ts
@@ -1,7 +1,7 @@
 import { DeployError, PinningNotSupportedError } from '../../errors.js'
 import type { UploadFunction } from '../../types.js'
 import { logger } from '../../utils/logger.js'
-import { referenceToCID } from '../../utils/swarm.js'
+import { referenceToCIDString } from '../../utils/swarm.js'
 
 const providerName = 'Swarmy'
 
@@ -31,7 +31,7 @@ export const uploadOnSwarmy: UploadFunction = async ({
   }
 
   return {
-    cid: referenceToCID(`0x${json.swarmReference}`).toString(),
+    cid: referenceToCIDString(`0x${json.swarmReference}`),
     rID: json.swarmReference,
   }
 }

--- a/src/utils/swarm.ts
+++ b/src/utils/swarm.ts
@@ -1,3 +1,4 @@
+import { base32 } from 'multiformats/bases/base32'
 import { create } from 'multiformats/hashes/digest'
 import { type Hex, toBytes } from 'ox/Hex'
 import * as varint from 'varint'
@@ -25,3 +26,6 @@ export const referenceToCID = (ref: Hex): Uint8Array =>
     SWARM_MANIFEST_CODEC,
     create(KECCAK_256_CODEC, toBytes(ref)).bytes,
   )
+
+export const referenceToCIDString = (ref: Hex): string =>
+  base32.encode(referenceToCID(ref))


### PR DESCRIPTION
## Summary
- `referenceToCID` returns a `Uint8Array`; calling `.toString()` on it produced a comma-separated decimal string rather than a valid CID.
- Added `referenceToCIDString` which base32-encodes the CID bytes via `multiformats/bases/base32`.
- Updated the Bee and Swarmy providers to use the new helper so returned CIDs are valid CIDv1 strings.