### PR TITLE
feat(pack): add --tar flag to produce TAR archives for Swarm

### DIFF
--- a/src/actions/pack.ts
+++ b/src/actions/pack.ts
@@ -48,18 +48,23 @@ export const packAction = async ({
   }
 
   if (tar) {
-    const tar = await packTAR(files)
-    return { bytes: tar, size }
-  } else {
-    const { rootCID, bytes } = await packCAR(files, name, dist)
+    const { bytes, output } = await packTAR(files, name, dist)
 
-    const cid = rootCID.toString()
-    if (onlyHash) {
-      console.log(cid)
-    } else {
-      logger.info(`Root CID: ${isTTY ? styleText('white', cid) : cid}`)
+    if (!onlyHash && output) {
+      logger.info(`TAR: ${isTTY ? styleText('white', output) : output}`)
     }
 
-    return { name, cid, bytes, files, size }
+    return { name, bytes, files, size }
   }
+
+  const { rootCID, bytes } = await packCAR(files, name, dist)
+
+  const cid = rootCID.toString()
+  if (onlyHash) {
+    console.log(cid)
+  } else {
+    logger.info(`Root CID: ${isTTY ? styleText('white', cid) : cid}`)
+  }
+
+  return { name, cid, bytes, files, size }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -231,8 +231,15 @@ cli.command<[string]>(
         type: 'boolean',
         short: 'v',
       },
+      {
+        name: 'tar',
+        description: 'Pack as a TAR archive (for Swarm) instead of a CAR',
+        type: 'boolean',
+        short: 't',
+      },
     ] as const,
-    description: 'Pack websites files into a CAR without uploading it anywhere',
+    description:
+      'Pack websites files into a CAR (or TAR with --tar) without uploading it anywhere',
   },
 )
 

--- a/src/utils/tar.ts
+++ b/src/utils/tar.ts
@@ -1,9 +1,15 @@
+import { writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { createTar, type TarFileItem } from 'nanotar'
 import type { FileEntry } from '../types.js'
 
+const tmp = tmpdir()
+
 export const packTAR = async (
   files: Omit<FileEntry, 'size'>[],
-): Promise<Uint8Array> => {
+  name?: string,
+  dir: string = tmp,
+): Promise<{ bytes: Uint8Array; output: string | null }> => {
   const entries: TarFileItem[] = []
 
   for (const { path, content } of files) {
@@ -28,5 +34,11 @@ export const packTAR = async (
     })
   }
 
-  return createTar(entries)
+  const bytes = createTar(entries) as Uint8Array
+
+  if (!name) return { bytes, output: null }
+
+  const output = `${dir}/${name}.tar`
+  await writeFile(output, bytes)
+  return { bytes, output }
 }

--- a/test/utils/tar.test.ts
+++ b/test/utils/tar.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'bun:test'
+import * as assert from 'node:assert'
+import { Readable } from 'node:stream'
+import { parseTar } from 'nanotar'
+import { packTAR } from '../../src/utils/tar.js'
+
+const te = new TextEncoder()
+
+const makeFile = (path: string, body: string) => ({
+  path,
+  content: Readable.from([te.encode(body)]) as unknown as ReturnType<
+    typeof import('node:fs').createReadStream
+  >,
+})
+
+describe('tar utils', () => {
+  describe('packTAR', () => {
+    it('packs files into a TAR and returns bytes without writing when no name', async () => {
+      const files = [
+        makeFile('a.txt', 'File A'),
+        makeFile('nested/b.txt', 'File B'),
+      ]
+
+      const { bytes, output } = await packTAR(files)
+
+      assert.ok(bytes instanceof Uint8Array)
+      assert.equal(output, null)
+
+      const entries = parseTar(bytes)
+      assert.equal(entries.length, 2)
+      assert.deepEqual(entries.map((e) => e.name).sort(), [
+        'a.txt',
+        'nested/b.txt',
+      ])
+    })
+
+    it('writes TAR to disk when name is provided', async () => {
+      const { tmpdir } = await import('node:os')
+      const { readFile, unlink } = await import('node:fs/promises')
+
+      const files = [makeFile('hello.txt', 'hello world')]
+      const { bytes, output } = await packTAR(files, 'packtar-test', tmpdir())
+
+      assert.ok(output?.endsWith('packtar-test.tar'))
+      const onDisk = await readFile(output as string)
+      assert.ok(onDisk.equals(bytes))
+      await unlink(output as string)
+    })
+  })
+})


### PR DESCRIPTION
Stacked on top of #138.

## Summary
- Expose `--tar` / `-t` on `omnipin pack` so users can prepare TAR archives for Swarm uploads instead of only CAR files.
- `packTAR` now optionally writes the archive to disk when a `name` is provided, mirroring `packCAR`'s signature and returning `{ bytes, output }`.
- Fix a variable-shadow bug in the pack action's tar branch and return a shape consistent with the CAR branch (`{ name, bytes, files, size }`), then log the on-disk output path.
- Added unit tests for `packTAR` covering both the in-memory and on-disk paths.

## Usage
```
omnipin pack ./dist --tar --dist ./out --name site
# -> ./out/site.tar
```