### PR TITLE
docs: tidy up

### DIFF
--- a/docs/cli/ens.md
+++ b/docs/cli/ens.md
@@ -1,12 +1,12 @@
 # `omnipin ens`
 
-Updates ENS domain Content-Hash with an IFPS CID.
+Updates ENS domain Content-Hash with an IPFS CID.
 
 ```sh
 omnipin ens <cid> <domain.eth>
 ```
 
-Requires a ENS owner's private key (`OMNIPIN_PK`) to be defined.
+Requires an ENS owner's private key (`OMNIPIN_PK`) to be defined.
 
 ::: warning
 
@@ -21,7 +21,7 @@ It is recommended to use multisig wallets for deployments instead of using a pri
 - Default: `mainnet`
 - Options: `mainnet`, `sepolia`
 
-EVM Chain to use for ENS deployment. Requires `--ens` option to be defined.
+EVM Chain to use for ENS deployment.
 
 ### `safe`
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -72,14 +72,13 @@ omnipin deploy --providers Storacha,Lighthouse
 More verbose logs.
 
 ```sh
-omnipin deploy --verbose --providers=Gateway3
+omnipin deploy --verbose --providers=Pinata
 
 # 📦 Packing dist (30.99KB)
 # 🟢 Root CID: bafybeihw4r72ynkl2zv4od2ru4537qx2zxjkwlzddadqmochzhe524t7qu
-# 🟢 Deploying with providers: Gateway3
-# POST https://gw3.io/api/v0/dag/import?size=33547&ts=... 200
-# POST https://some-node.gtw3.io/api/v0/dag/import?sargs=...-...-...-...&ssig=.......-...-...%3D%3D 200
-# POST https://gw3.io/api/v0/pin/add?arg=...&ts=...&name=dist 200
+# 🟢 Deploying with providers: Pinata
+# POST https://uploads.pinata.cloud/v3/files 200
+# POST https://api.pinata.cloud/v3/files/public/... 200
 # ✓ [>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] Finished in 3s
 # ✔ Deployed across all providers
 # Open in a browser:
@@ -91,9 +90,9 @@ omnipin deploy --verbose --providers=Gateway3
 
 Deploy using a [Safe](https://safe.global) multisig wallet. Requires private key of a Safe owner/delegate to sign a transaction. [EIP-3770](https://eips.ethereum.org/EIPS/eip-3770) addresses and ENS names are supported. Mainnet is used by default.
 
-The update will be sent to the Safe Transaction Service. `OMNIPIN_PK` must be a proposer's privat key.
+The update will be sent to the Safe Transaction Service. `OMNIPIN_PK` must be a proposer's private key.
 
-In case the `roles-mod-address` option is specified, a transaction will submitted via the Zodiac Roles module instead, skipping the Safe Transaction Service and going directly onchain. Just like with EOA, a transaction is simulated locally first.
+In case the `roles-mod-address` option is specified, a transaction will be submitted via the Zodiac Roles module instead, skipping the Safe Transaction Service and going directly onchain. Just like with EOA, a transaction is simulated locally first.
 
 ```sh
 # Propose transaction to Safe

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -1,6 +1,6 @@
 # `omnipin status`
 
-Checks the deployment status of a IPFS CID across providers.
+Checks the deployment status of an IPFS CID across providers.
 
 ```sh
 omnipin status <cid>

--- a/docs/cli/zodiac.md
+++ b/docs/cli/zodiac.md
@@ -14,13 +14,13 @@ If `OMNIPIN_PK` is not specified, a private key will be generated on the spot.
 ```sh
 omnipin zodiac --safe 0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262 0x6aBD167a6a29Fd9aDcf4365Ed46C71c913B7c1B1 0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63
 
-# omnipin zodiac --safe 0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262 0x6aBD167a6a29Fd9aDcf4365Ed46C71c913B7c1B1 --verbose
+# omnipin zodiac --safe 0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262 0x6aBD167a6a29Fd9aDcf4365Ed46C71c913B7c1B1 0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63 --verbose
 # ⚠️ `OMNIPIN_PK` environment variable not set.
 # 🟢 Generating a Secp256k1 keypair
 #    0xeb12099469558be35d53d606e1d5e69d0854c57ef6658e909325c5a0e6493415
 # 🟢 Save the private key and do not share it to anyone
 # 🟢 Created zodiac.json in current directory
-# Open in a browser: https://app.safe.global/apps/open?safe=:0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262&appUrl=https%3A%2F%2Fapps-portal.safe.global%2Ftx-builder
+# Open in a browser: https://app.safe.global/apps/open?safe=eth:0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262&appUrl=https%3A%2F%2Fapps-portal.safe.global%2Ftx-builder
 # Upload zodiac.json in the UI
 ```
 

--- a/docs/docs/ci-cd.md
+++ b/docs/docs/ci-cd.md
@@ -4,7 +4,7 @@ Omnipin can be integrated with CI/CD pipelines to deploy dApps automatically.
 
 ## GitHub Actions
 
-Omnipin uses this GitHub Action to deploy it's own website.
+Omnipin uses this GitHub Action to deploy its own website.
 
 ```yaml
 name: Deploy with Omnipin

--- a/docs/docs/ci-cd.md
+++ b/docs/docs/ci-cd.md
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - name: Install Omnipin
-        run: bun i -g omnipin@1.2.1
+        run: bun i -g omnipin
       - name: Build website
         run: bun i && bun run build
       - name: Deploy the site
@@ -49,7 +49,7 @@ deploy:
   stage: deploy
   image: node:22
   script:
-    - pnpm i -g omnipin@1.2.1
+    - pnpm i -g omnipin
     - pnpm i && pnpm build
     - omnipin deploy --strict
   only:

--- a/docs/docs/how-it-works.md
+++ b/docs/docs/how-it-works.md
@@ -109,7 +109,7 @@ A transaction is signed by a private key provided via `OMNIPIN_PK` and is immedi
 
 In case EOA is still required and neither Proposer nor Zodiac Roles options are available, it is recommended to take a list of security measures to minimize the potential risks of using an EOA for managing the ENS name:
 
-* Don't use the account for storing any assets other than a tiny portion of ETH required to pay the transaction feees
+* Don't use the account for storing any assets other than a tiny portion of ETH required to pay the transaction fees
 * Save the private key in CI secrets to not be able to retrieve it from elsewhere
 * If an ENS name is wrapped, unwrap it and set an owner to a different Ethereum account. In case the private key gets leaked, it is still possible to revoke access by changing the manager address.
 
@@ -122,7 +122,7 @@ While the Proposer flow is the safest and is the most secure, it is also the mos
 #### Setup
 
 1. Head over to the [Safe app](https://app.safe.global) and create a new wallet, if you don't have one yet.
-2. Create a new Ethereum account that will be used for proposing transactions, save it's private key to `OMNIPIN_PK`.
+2. Create a new Ethereum account that will be used for proposing transactions, save its private key to `OMNIPIN_PK`.
 3. To add a proposer, go to the Safe app > Settings > Setup. Scroll down to "Proposers" and click "Add Proposer". You can add multiple proposers to your Safe, but only one can be used at a time.
 
 ![Proposer UI](/proposer.png)
@@ -142,15 +142,15 @@ A transaction is signed by a private key provided via `OMNIPIN_PK` and is immedi
 4. Generate a JSON for a batch transaction setup via `omnipin zodiac`:
 
 ```sh
-omnipin zodiac --safe 0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262 0x6aBD167a6a29Fd9aDcf4365Ed46C71c913B7c1B1
+omnipin zodiac --safe 0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262 0x6aBD167a6a29Fd9aDcf4365Ed46C71c913B7c1B1 0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63
 
-# omnipin zodiac --safe 0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262 0x6aBD167a6a29Fd9aDcf4365Ed46C71c913B7c1B1 --verbose
+# omnipin zodiac --safe 0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262 0x6aBD167a6a29Fd9aDcf4365Ed46C71c913B7c1B1 0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63 --verbose
 # ⚠️ `OMNIPIN_PK` environment variable not set.
 # 🟢 Generating a Secp256k1 keypair
 #    0xeb12099469558be35d53d606e1d5e69d0854c57ef6658e909325c5a0e6493415
 # 🟢 Save the private key and do not share it to anyone
 # 🟢 Created zodiac.json in current directory
-# Open in a browser: https://app.safe.global/apps/open?safe=:0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262&appUrl=https%3A%2F%2Fapps-portal.safe.global%2Ftx-builder
+# Open in a browser: https://app.safe.global/apps/open?safe=eth:0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262&appUrl=https%3A%2F%2Fapps-portal.safe.global%2Ftx-builder
 # Upload zodiac.json in the UI
 ```
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Omnipin supports one of the these JavaScript runtimes: [Node.js](https://nodejs.org) (20+), [Deno](https://deno.com) (2.2.11+) and [Bun](https://bun.sh).
+Omnipin supports one of these JavaScript runtimes: [Node.js](https://nodejs.org) (20+), [Deno](https://deno.com) (2.2.11+) and [Bun](https://bun.sh).
 
 :::code-group
 
@@ -108,7 +108,7 @@ Updating ENS Content-Hash record requires paying a network fee. The fee varies d
 
 Using a private key of the ENS name manager account imposes significant security risks. In case of environment compromise, an attacker is able to update the ENS name to a malicious version.
 
-One of the unique features that Omnipin offers is [Safe](https://safe.global) integration. Instead of EOA managing the ENS name, a multi-signature wallet is put in the front. Such approach allows for advancing security for ENS update pipelines, such as multi-factor authorisation with the [Proposer Flow](/docs/how-it-works#proposer) or role-based permissions with [Zodiac Roles](/docs/how-it-works#zodiac-roles).
+One of the unique features that Omnipin offers is [Safe](https://safe.global) integration. Instead of EOA managing the ENS name, a multi-signature wallet is put in the front. Such an approach allows for advanced security for ENS update pipelines, such as multi-factor authorisation with the [Proposer Flow](/docs/how-it-works#proposer) or role-based permissions with [Zodiac Roles](/docs/how-it-works#zodiac-roles).
 
 Proposer flow requires additional factor of authorisation on every deploy, which might be excessive for some websites, especially those with frequent updates. Because of that, the guide will instead cover setup with Zodiac Roles.
 
@@ -119,15 +119,15 @@ Proposer flow requires additional factor of authorisation on every deploy, which
 3. Generate a JSON for a batch transaction setup via `omnipin zodiac`:
 
 ```sh
-omnipin zodiac --safe 0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262 0x6aBD167a6a29Fd9aDcf4365Ed46C71c913B7c1B1
+omnipin zodiac --safe 0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262 0x6aBD167a6a29Fd9aDcf4365Ed46C71c913B7c1B1 0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63
 
-# omnipin zodiac --safe 0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262 0x6aBD167a6a29Fd9aDcf4365Ed46C71c913B7c1B1 --verbose
+# omnipin zodiac --safe 0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262 0x6aBD167a6a29Fd9aDcf4365Ed46C71c913B7c1B1 0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63 --verbose
 # ⚠️ `OMNIPIN_PK` environment variable not set.
 # 🟢 Generating a Secp256k1 keypair
 #    0xeb12099469558be35d53d606e1d5e69d0854c57ef6658e909325c5a0e6493415
 # 🟢 Save the private key and do not share it to anyone
 # 🟢 Created zodiac.json in current directory
-# Open in a browser: https://app.safe.global/apps/open?safe=:0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262&appUrl=https%3A%2F%2Fapps-portal.safe.global%2Ftx-builder
+# Open in a browser: https://app.safe.global/apps/open?safe=eth:0x0Fd2cA6b1a52a1153dA0B31D02fD53854627D262&appUrl=https%3A%2F%2Fapps-portal.safe.global%2Ftx-builder
 # Upload zodiac.json in the UI
 ```
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - name: Install Omnipin
-        run: bun i -g omnipin@1.2.1
+        run: bun i -g omnipin
       - name: Build website
         run: bun i && bun run build
       - name: Deploy the site

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-Omnipin supports one of the these JavaScript runtimes: [Node.js](https://nodejs.org) (20+), [Deno](https://deno.com) (2.2.11+) and [Bun](https://bun.sh).
+Omnipin supports one of these JavaScript runtimes: [Node.js](https://nodejs.org) (20+), [Deno](https://deno.com) (2.2.11+) and [Bun](https://bun.sh).
 
 ## JavaScript package managers
 

--- a/docs/docs/ipfs.md
+++ b/docs/docs/ipfs.md
@@ -99,7 +99,7 @@ Omnipin supports a wide range of different IPFS providers.
       <td>❌</td>
     </tr>
     <tr>
-      <td><a href="#aleph">SimplePage</a></td>
+      <td><a href="#simplepage">SimplePage</a></td>
       <td><a href="https://simplepage.eth.limo/architecture">Docs</a></td>
       <td>✅</td>
       <td>✅</td>
@@ -139,12 +139,12 @@ It is recommended to bridge a bit of FIL first, and then swap a portion of it to
 USDfc, since cross-chain swaps for USDfc have low liquidity in pools. For most
 (<10GB) uploads, $1 of USDfc and 0.1 FIL should be enough.
 
-If using the calibration testnet, you can get USDFc through a faucet as well
+If using the calibration testnet, you can get USDfc through a faucet as well
 [here](https://forest-explorer.chainsafe.dev/faucet/calibnet_usdfc).
 
 A Filecoin SP (storage provider) is chosen at random from the list of approved
 providers for convenience, if there have been no uploads prior. Otherwise a
-previously used SP will be used. Provider choice can be overriden with
+previously used SP will be used. Provider choice can be overridden with
 `OMNIPIN_FILECOIN_SP_URL` and `OMNIPIN_FILECOIN_SP_ADDRESS` environment
 variables. If only `OMNIPIN_FILECOIN_SP_ADDRESS` is specified, the provider URL
 is fetched from the registry.
@@ -202,7 +202,7 @@ variable.
 
 ## Storacha
 
-- API env variables: `STORACHA_TOKEN`, `STORACHA_PROOF`
+- API env variables: `OMNIPIN_STORACHA_TOKEN`, `OMNIPIN_STORACHA_PROOF`
 
 Generating a key for Storacha requires a CLI tool.
 
@@ -261,7 +261,7 @@ storacha space use <space DID>
 ```
 
 When both the account and the space are set up, you need to generate a unique
-private key. It is required to create a delegation proof to be able ot upload
+private key. It is required to create a delegation proof to be able to upload
 files to the space.
 
 ```bash [Terminal]
@@ -291,7 +291,7 @@ OMNIPIN_STORACHA_PROOF=mAYIEAJM...uIXm2rXyL...Zxe4Bh6g2RQZwjDUcw3qrvMNXzu2pg/rdd
 - API env variables: `OMNIPIN_PINATA_TOKEN`
 
 Go to the dashboard page, then "API Keys" under "Developer" section. Click "New
-Key". An API key creation dialog should apppear. Select the checkboxes related
+Key". An API key creation dialog should appear. Select the checkboxes related
 to pinning. Click "Generate API Key".
 
 ![Pinata dashboard](/pinata.png)
@@ -336,7 +336,7 @@ the `OMNIPIN_BLOCKFROST_TOKEN` environment variable.
 `OMNIPIN_ALEPH_TOKEN` is the private key of the account. Buy
 [$ALEPH](https://aleph.cloud/aleph-token) token for an account, around the same
 amount as the size of the website distribution. By default, mainnet will be
-used, but you can specify the chain with `OMNIPIN_ALEPH_CHAIN`. Supported chain
+used, but you can specify the chain with `OMNIPIN_ALEPH_CHAIN`. Supported chains
 are Ethereum (`ETH`), Avalanche (`AVAX`) and Base (`BASE`).
 
 ## SimplePage

--- a/docs/docs/swarm.md
+++ b/docs/docs/swarm.md
@@ -7,7 +7,7 @@ Omnipin supports uploading on the [Swarm](https://ethswarm.org) decentralized ne
 - API token env variables: `OMNIPIN_SWARMY_TOKEN`
 - Supported methods: Upload
 
-Omnipin supports uploading on the [Swarm](https://ethswarm.org) decentralized network via [Swarmy](https://swarmy.cloud), a storage provider. A website is not possible to upload both on Swarm and IPFS, so when opting in for Swarmy, other providers will be ignored.
+Omnipin supports uploading on the [Swarm](https://ethswarm.org) decentralized network via [Swarmy](https://swarmy.cloud), a storage provider. A website cannot be uploaded to both Swarm and IPFS at the same time, so when opting in for Swarmy, other providers will be ignored.
 
 ### Setup
 
@@ -50,13 +50,14 @@ curl -sX POST http://localhost:1633/stamps/<amount>/<depth>
 # }
 ```
 
-Add the batch ID to the environment variables:
+Add the batch ID and the Bee node URL to the environment variables:
 
 ```sh
-OMNIPIN_BEE_TOKEN=8fc...2c6b
+OMNIPIN_BEE_TOKEN=8fc...8552c6b
+OMNIPIN_BEE_URL=http://localhost:1633
 ```
 
-Then run the the deployment command:
+Then run the deployment command:
 
 ```sh
 omnipin deploy --ens omnipin.eth --safe eth:0x...

--- a/docs/docs/why.md
+++ b/docs/docs/why.md
@@ -2,7 +2,7 @@
 
 ## Fragility of classic front-ends
 
-Decentralized web hosting is often an overlooked aspect with dApp infrastructure. While the underlying smart contracts are open, permissionless and verifiable, the front-end itself is usually hosted on some central hosting service, such as Vercel or Netlify.
+Decentralized web hosting is often an overlooked aspect of dApp infrastructure. While the underlying smart contracts are open, permissionless and verifiable, the front-end itself is usually hosted on some central hosting service, such as Vercel or Netlify.
 
 The crypto industry has faced numerous cases of different front-end attacks resulting in loss of millions of dollars, ranging from DNS hijacks to developer machine compromises.
 
@@ -25,7 +25,7 @@ It is a common misconception that uploading files on IPFS makes them distributed
 
 1. **Replication is not enforced by IPFS in any way**. Uploading a file to the network **does not** reproduce it across many other nodes. While certain storage providers may pin the same content onto their own cluster of nodes, it is still bound to the same provider. What this means is that you have to replicate content on your own.
 
-2. **IPFS doesn't provide any guarantees on content persistence**. Storage providers may unpin or delete content at any point of time, for example if you stop paying a service subscription. The content is available on the network as long as one or more node have it and are discoverable anyhow, for example DHT.
+2. **IPFS doesn't provide any guarantees on content persistence**. Storage providers may unpin or delete content at any point of time, for example if you stop paying a service subscription. The content is available on the network as long as one or more nodes have it and are discoverable somehow, for example via the DHT.
 
 One of the key features of Omnipin is automatic re-pinning of content for IPFS on many independent IPFS storage providers. The full list is available [here](/docs/ipfs).
 
@@ -33,9 +33,9 @@ One of the key features of Omnipin is automatic re-pinning of content for IPFS o
 
 ## Decentralized vendor lock-in
 
-Certain platforms advertise themselves as "decentralized web hosting". While the app hosted on such platform itself might be somewhat decentralized (for example using ENS instead of DNS), it does not mean that such a platform can't take the website down or just go in vain (for example because of business not going well). The reliability of the application is bound to the platform.
+Certain platforms advertise themselves as "decentralized web hosting". While the app hosted on such platform itself might be somewhat decentralized (for example using ENS instead of DNS), it does not mean that such a platform can't take the website down or just go out of business (for example because of business not going well). The reliability of the application is bound to the platform.
 
-Omnipin does not impose such risks because it is not a platform. It is instead a tool that talks to infrastructure providers and protocols directly without middlemen. There is no "Sign Up" button. The underlying infrastucture is chosen by the user.
+Omnipin does not impose such risks because it is not a platform. It is instead a tool that talks to infrastructure providers and protocols directly without middlemen. There is no "Sign Up" button. The underlying infrastructure is chosen by the user.
 
 Omnipin never uses mutable references besides ENS and DNSLink, making sure that all of the content references are immutable and deterministic (IPFS CIDs and Swarm reference IDs). Such approach additionally provides a transparent and permanent history of website changes for an ENS name.
 
@@ -45,10 +45,10 @@ Any website may be updated at any time by pushing a new version without much not
 
 While this is indeed very convenient, such approach is not good for security. In case of developer machine compromise, there are almost no barriers for publishing an exploited version of the web app without anyone being able to stop the attacker before the damage is done. This is exactly what happened during the [Safe front-end hack](https://www.ledger.com/blog-learning-from-the-bybit-safe-attack).
 
-Such status quo should not apply to dApps, especially financially sensitive ones where security is of upmost importance. That is the primary reason why Omnipin integrates with the [Safe Proposer Flow](https://help.safe.global/en/articles/235770-proposers) for ENS update management.
+Such status quo should not apply to dApps, especially financially sensitive ones where security is of utmost importance. That is the primary reason why Omnipin integrates with the [Safe Proposer Flow](https://help.safe.global/en/articles/235770-proposers) for ENS update management.
 
-With a multi-sig wallet sitting on top of an ENS name it is possible to add an multi-factor authorization layer for website updates. It is also not required to be one of the wallet owners to propose ENS updates, which significantly minimizes potential damage from an owner account getting compromised.
+With a multi-sig wallet sitting on top of an ENS name it is possible to add a multi-factor authorization layer for website updates. It is also not required to be one of the wallet owners to propose ENS updates, which significantly minimizes potential damage from an owner account getting compromised.
 
 However, such high security requirements do not apply to everybody. For that reason, Omnipin alternatively integrates with the [Zodiac Roles](https://docs.roles.gnosisguild.org) module. The module allows creating a restricted role that is only allowed to call a specific function on a specific smart contract.
 
-Omnipin uses Zodiac Roles to create a special role that is narrowed to only ENS website reference on an ENS name's resolver. Such integration provides moderate security benefits to users who do not wish to have a mult-factor authorization flow.
+Omnipin uses Zodiac Roles to create a special role that is narrowed to only ENS website reference on an ENS name's resolver. Such integration provides moderate security benefits to users who do not wish to have a multi-factor authorization flow.


### PR DESCRIPTION
## Summary
- Fix typos, grammar, and consistency issues across all docs pages
- Correct factual issues: SimplePage anchor link, Gateway3 → Pinata example, missing zodiac resolver positional, Safe URL EIP-3770 prefix, undocumented OMNIPIN_BEE_URL
- Unpin omnipin version in CI examples