### PR TITLE
feat(bee): make BEE_URL optional, default to localhost:1633

### DIFF
--- a/docs/docs/swarm.md
+++ b/docs/docs/swarm.md
@@ -35,7 +35,7 @@ omnipin deploy --ens omnipin.eth --safe eth:0x...
 
 ## Bee node
 
-- API token env variables: `OMNIPIN_BEE_TOKEN`, `OMNIPIN_BEE_URL`
+- API token env variables: `OMNIPIN_BEE_TOKEN`, `OMNIPIN_BEE_URL` (optional, defaults to `http://localhost:1633`)
 - Supported methods: Upload
 
 ### Running a Bee node
@@ -113,12 +113,14 @@ curl -sX POST http://localhost:1633/stamps/<amount>/<depth>
 # }
 ```
 
-Add the batch ID and the Bee node URL to the environment variables:
+Add the batch ID to the environment variables:
 
 ```sh
 OMNIPIN_BEE_TOKEN=8fc...8552c6b
-OMNIPIN_BEE_URL=http://localhost:1633
+# OMNIPIN_BEE_URL=http://localhost:1633  # optional, this is the default
 ```
+
+Set `OMNIPIN_BEE_URL` only if your Bee node is not running on `http://localhost:1633`.
 
 Then run the deployment command:
 

--- a/skills/omnipin-deploy/SKILL.md
+++ b/skills/omnipin-deploy/SKILL.md
@@ -162,7 +162,7 @@ Use these env var names exactly. Do not invent variants.
 | Provider | `--providers` value | Required env vars |
 |----------|---------------------|-------------------|
 | Swarmy   | `Swarmy`            | `OMNIPIN_SWARMY_TOKEN` |
-| Bee node | `Bee`               | `OMNIPIN_BEE_TOKEN` (postage batch ID), `OMNIPIN_BEE_URL` |
+| Bee node | `Bee`               | `OMNIPIN_BEE_TOKEN` (postage batch ID); optional `OMNIPIN_BEE_URL` (defaults to `http://localhost:1633`) |
 
 ### ENS / Safe
 

--- a/src/providers/swarm/bee.ts
+++ b/src/providers/swarm/bee.ts
@@ -5,11 +5,13 @@ import { referenceToCIDString } from '../../utils/swarm.js'
 
 const providerName = 'Bee'
 
-export const uploadOnBee: UploadFunction<{ beeURL: string }> = async ({
+export const DEFAULT_BEE_URL = 'http://localhost:1633'
+
+export const uploadOnBee: UploadFunction<{ beeURL?: string }> = async ({
   token,
   bytes,
   verbose,
-  beeURL,
+  beeURL = DEFAULT_BEE_URL,
   first,
 }) => {
   if (!first) throw new PinningNotSupportedError(providerName)


### PR DESCRIPTION
## Summary

- `OMNIPIN_BEE_URL` is now optional and defaults to `http://localhost:1633`, which is where a locally-running Bee node listens by default.
- Users only need to set `OMNIPIN_BEE_URL` if their node is reachable at a different host/port (remote node, custom port, etc.).
- Updated docs (`docs/docs/swarm.md`) and the deploy skill (`skills/omnipin-deploy/SKILL.md`) to reflect the new default.