### PR TITLE
feat: add IPFS.NINJA provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         run: bun test:report
         env:
           OMNIPIN_LIGHTHOUSE_TOKEN: ${{ secrets.OMNIPIN_LIGHTHOUSE_TOKEN }}
+          OMNIPIN_IPFS_NINJA_TOKEN: ${{ secrets.OMNIPIN_IPFS_NINJA_TOKEN }}
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/docs/docs/ipfs.md
+++ b/docs/docs/ipfs.md
@@ -43,6 +43,14 @@ Omnipin supports a wide range of different IPFS providers.
       <td>✅</td>
     </tr>
     <tr>
+      <td><a href="#ipfs-ninja">IPFS.NINJA</a></td>
+      <td><a href="https://ipfs.ninja/docs/api/pinning">Docs</a></td>
+      <td>❌</td>
+      <td>✅</td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
       <td><a href="#pinata">Pinata</a></td>
       <td><a href="https://docs.pinata.cloud/files/uploading-files">Docs</a></td>
       <td>❌</td>
@@ -191,6 +199,25 @@ Filebase provides an RPC API which can be used for pinning.
 Request a new token in the "IPFS RPC API Keys" section in "Access Keys" page of
 the Filebase console. Save the token to the `OMNIPIN_FILEBASE_TOKEN` environment
 variable.
+
+## IPFS.NINJA
+
+- API env variables: `OMNIPIN_IPFS_NINJA_TOKEN`
+
+[IPFS.NINJA](https://ipfs.ninja) is a paid IPFS pinning service with a free
+tier. Omnipin uploads via the CAR import endpoint, which preserves the local
+root CID exactly (no re-chunking or re-hashing).
+
+Sign up at [ipfs.ninja/signup](https://ipfs.ninja/signup), then create an API
+key from the [API Keys page](https://ipfs.ninja/api-keys). The key starts with
+`bws_`. Save it as:
+
+```sh
+OMNIPIN_IPFS_NINJA_TOKEN=bws_your_api_key_here
+```
+
+Maximum CAR upload size is **100 MB** per request. Larger sites need to be
+split across multiple imports or use a different provider.
 
 ## Pinata
 

--- a/skills/omnipin-deploy/SKILL.md
+++ b/skills/omnipin-deploy/SKILL.md
@@ -37,7 +37,7 @@ Follow this flow strictly. Do not invent env var names or providers — only use
 
 Ask the user to pick one or more providers. Present the list grouped by network:
 
-- **IPFS**: `Filecoin`, `Spec`, `Filebase`, `Pinata`, `4EVERLAND`, `QuickNode`, `Lighthouse`, `Blockfrost`, `Aleph`, `SimplePage`
+- **IPFS**: `Filecoin`, `Spec`, `Filebase`, `IPFSNinja`, `Pinata`, `4EVERLAND`, `QuickNode`, `Lighthouse`, `Blockfrost`, `Aleph`, `SimplePage`
 - **Swarm** (mutually exclusive with IPFS providers): `Bee` (recommended), `Swarmy`
 
 Important constraints:
@@ -152,6 +152,7 @@ Use these env var names exactly. Do not invent variants.
 | Filecoin     | `Filecoin`          | `OMNIPIN_FILECOIN_TOKEN` — private key of a wallet funded with FIL + USDfc, see [Funding a Filecoin wallet](#funding-a-filecoin-wallet). **Do not ask for SP overrides by default**; Omnipin picks a storage provider automatically. Only mention `OMNIPIN_FILECOIN_SP_URL` / `OMNIPIN_FILECOIN_SP_ADDRESS` if the user explicitly wants to pin a specific SP. |
 | Spec (generic pinning service) | `Spec` | `OMNIPIN_SPEC_TOKEN`, `OMNIPIN_SPEC_URL` |
 | Filebase     | `Filebase`          | `OMNIPIN_FILEBASE_TOKEN`. For upload+pin also `OMNIPIN_FILEBASE_BUCKET_NAME` |
+| IPFS.NINJA   | `IPFSNinja`         | `OMNIPIN_IPFS_NINJA_TOKEN` (key starts with `bws_`; generate at <https://ipfs.ninja/api-keys>). Max 100 MB CAR per upload. |
 | Pinata       | `Pinata`            | `OMNIPIN_PINATA_TOKEN` (JWT) |
 | 4EVERLAND    | `4EVERLAND`         | `OMNIPIN_4EVERLAND_TOKEN` |
 | QuickNode    | `QuickNode`         | `OMNIPIN_QUICKNODE_TOKEN` |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,10 @@ import {
   uploadOnFilebase,
 } from './providers/ipfs/filebase.js'
 import { uploadToFilecoin } from './providers/ipfs/filecoin.js'
+import {
+  statusOnIpfsNinja,
+  uploadOnIpfsNinja,
+} from './providers/ipfs/ipfs-ninja.js'
 import { uploadOnLighthouse } from './providers/ipfs/lighthouse.js'
 import { statusOnPinata, uploadOnPinata } from './providers/ipfs/pinata.js'
 import { pinOnQuicknode } from './providers/ipfs/quicknode.js'
@@ -77,6 +81,13 @@ export const PROVIDERS: Record<
   LIGHTHOUSE_TOKEN: {
     name: 'Lighthouse',
     upload: uploadOnLighthouse,
+    supported: 'both',
+    protocol: 'ipfs',
+  },
+  IPFS_NINJA_TOKEN: {
+    name: 'IPFSNinja',
+    upload: uploadOnIpfsNinja,
+    status: statusOnIpfsNinja,
     supported: 'both',
     protocol: 'ipfs',
   },

--- a/src/providers/ipfs/ipfs-ninja.ts
+++ b/src/providers/ipfs/ipfs-ninja.ts
@@ -1,0 +1,101 @@
+import { base64pad } from 'multiformats/bases/base64'
+import { DeployError } from '../../errors.js'
+import type { PinStatus, StatusFunction, UploadFunction } from '../../types.js'
+import { logger } from '../../utils/logger.js'
+
+const providerName = 'IPFSNinja'
+
+const API_URL = 'https://api.ipfs.ninja'
+
+export const uploadOnIpfsNinja: UploadFunction = async ({
+  bytes,
+  name,
+  first,
+  token,
+  verbose,
+  cid,
+}) => {
+  if (first) {
+    const res = await fetch(`${API_URL}/upload/new`, {
+      method: 'POST',
+      headers: {
+        'X-Api-Key': token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        content: base64pad.baseEncode(bytes),
+        car: true,
+        description: name,
+      }),
+    })
+
+    if (verbose) logger.request('POST', res.url, res.status)
+
+    const json = await res.json()
+
+    if (!res.ok)
+      throw new DeployError(
+        providerName,
+        json.error?.message || json.error || 'Unknown error',
+      )
+
+    return { cid: json.cid ?? cid }
+  }
+
+  // Pin existing CID
+  const res = await fetch(`${API_URL}/pin`, {
+    method: 'POST',
+    headers: {
+      'X-Api-Key': token,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ cid, description: name }),
+  })
+
+  if (verbose) logger.request('POST', res.url, res.status)
+
+  const json = await res.json()
+
+  if (!res.ok)
+    throw new DeployError(
+      providerName,
+      json.error?.message || json.error || 'Unknown error',
+    )
+
+  return { cid, status: 'queued' }
+}
+
+export const statusOnIpfsNinja: StatusFunction = async ({
+  cid,
+  auth,
+  verbose,
+}) => {
+  const res = await fetch(`${API_URL}/pin/${cid}`, {
+    headers: {
+      'X-Api-Key': auth.token ?? '',
+    },
+  })
+
+  if (verbose) logger.request('GET', res.url, res.status)
+
+  if (res.status === 404) return { pin: 'not pinned' }
+
+  const json = await res.json()
+
+  if (!res.ok)
+    throw new DeployError(
+      providerName,
+      json.error?.message || json.error || 'Unknown error',
+    )
+
+  const pin: PinStatus =
+    json.status === 'pinned'
+      ? 'pinned'
+      : json.status === 'pinning'
+        ? 'queued'
+        : json.status === 'failed'
+          ? 'failed'
+          : 'unknown'
+
+  return { pin }
+}

--- a/test/providers/ipfs-ninja.test.ts
+++ b/test/providers/ipfs-ninja.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'bun:test'
+
+import { PROVIDERS } from '../../src/constants.js'
+import { packCAR, walk } from '../../src/index.js'
+import {
+  statusOnIpfsNinja,
+  uploadOnIpfsNinja,
+} from '../../src/providers/ipfs/ipfs-ninja.js'
+
+const { upload, status } = PROVIDERS.IPFS_NINJA_TOKEN
+const token = Bun.env.OMNIPIN_IPFS_NINJA_TOKEN
+
+if (!token) throw new Error('Missing OMNIPIN_IPFS_NINJA_TOKEN')
+
+describe('IPFSNinja', () => {
+  it('is registered in PROVIDERS with both upload and status', () => {
+    expect(upload).toBe(uploadOnIpfsNinja)
+    expect(status).toBe(statusOnIpfsNinja)
+    expect(PROVIDERS.IPFS_NINJA_TOKEN.supported).toBe('both')
+    expect(PROVIDERS.IPFS_NINJA_TOKEN.protocol).toBe('ipfs')
+    expect(PROVIDERS.IPFS_NINJA_TOKEN.name).toBe('IPFSNinja')
+  })
+
+  describe('status', () => {
+    it(
+      'returns "not pinned" for an unknown CID',
+      async () => {
+        const result = await statusOnIpfsNinja({
+          cid: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdq',
+          auth: { token },
+        })
+        expect(result.pin).toBe('not pinned')
+      },
+      { timeout: 15_000 },
+    )
+  })
+
+  describe('upload', () => {
+    it(
+      'uploads a CAR and preserves the root CID',
+      async () => {
+        const [size, files] = await walk('./dist', false)
+        const car = await packCAR(files, 'test')
+
+        const { cid } = await uploadOnIpfsNinja({
+          token,
+          name: `omnipin-test-${Date.now()}`,
+          first: true,
+          bytes: car.bytes,
+          cid: car.rootCID.toString(),
+          size,
+        })
+
+        expect(cid).toBe(car.rootCID.toString())
+      },
+      { timeout: 60_000 },
+    )
+  })
+
+  describe('pin', () => {
+    it(
+      're-pins an existing CID via the /pin endpoint',
+      async () => {
+        // ipfs.ninja's /pin endpoint requires CIDs that start with Qm or bafy
+        // (dag-pb). This is a CID we previously uploaded from the omnipin
+        // smoke test, so re-pinning is a no-op (`deduped: true`).
+        const cid =
+          'bafybeiehlvkyfqt3wpfof27bcrhb4wklk7nwouadp7rq5djos2avoaciu4'
+
+        const result = await uploadOnIpfsNinja({
+          token,
+          cid,
+          name: 'omnipin pin test',
+          first: false,
+          bytes: new Uint8Array(),
+          size: 0,
+        })
+
+        expect(result.cid).toBe(cid)
+        expect(result.status).toBe('queued')
+      },
+      { timeout: 30_000 },
+    )
+  })
+})


### PR DESCRIPTION
Adds support for [ipfs.ninja](https://ipfs.ninja) as an IPFS pinning provider.

## Implementation
- **Upload (first provider):** `POST /upload/new` with base64-encoded CAR + `car: true`. Preserves the local root CID exactly — no re-chunking or re-hashing.
- **Pin (subsequent provider):** `POST /pin` with the existing CID.
- **Status:** `GET /pin/:cid` returning `pinned` / `pinning` / `failed` (mapped to omnipin's `PinStatus`).
- **Auth:** `X-Api-Key: bws_...` header (server-side API key).
- **Limits:** 100 MB per CAR upload.

## Verification
- Live deploy via `omnipin deploy --providers IPFSNinja` confirmed end-to-end: CAR uploaded, root CID returned matches the locally-computed one (`bafybeiehlvkyfqt3wpfof27bcrhb4wklk7nwouadp7rq5djos2avoaciu4`).
- All 4 unit tests pass against the live API.
- CI secret `OMNIPIN_IPFS_NINJA_TOKEN` configured.

## Docs
- Added to `docs/docs/ipfs.md` (provider table + setup section).
- Added to `skills/omnipin-deploy/SKILL.md` (provider list + reference table).

## API references
- https://ipfs.ninja/docs/api/car-import
- https://ipfs.ninja/docs/api/pinning
- https://ipfs.ninja/docs/api/authentication