### PR TITLE
feat(topup): support Filecoin via Squid Router

### DIFF
--- a/docs/cli/topup.md
+++ b/docs/cli/topup.md
@@ -96,7 +96,8 @@ which wraps Axelar's cross-chain bridge with destination-side gas payment
 and an on-chain DEX swap on Filecoin (Sushiswap V3 against the
 `axlUSDC` / `USDfc` / `WFIL` pools). This means a single source-chain
 transaction can deliver native FIL **and** USDfc on Filecoin without the
-recipient needing FIL for destination gas.
+recipient needing FIL for destination gas. The bridged USDfc is then
+automatically deposited into **Filecoin Pay** for storage payments.
 
 For each invocation:
 
@@ -108,6 +109,11 @@ For each invocation:
 3. The FIL leg is executed and polled on Squid's `/v2/status` until
    `success`.
 4. The USDfc leg is executed and polled the same way.
+5. After the USDfc balance arrives on Filecoin, it is deposited into
+   **Filecoin Pay** via `depositWithPermit` (or
+   `depositWithPermitAndApproveOperator` for first-time deposits). This
+   credits the storage payment contract so the `Filecoin` IPFS provider
+   can use the funds for dataset uploads.
 
 If Squid's API returns a non-2xx, the error includes a deeplink to the
 Squid web UI (`https://app.squidrouter.com/?chains=…&tokens=…`) preserving
@@ -155,5 +161,9 @@ rate-limits quote requests per `fromAddress`).
   errors during heavy use. Omnipin retries with exponential backoff.
 - USDfc is the canonical USD-pegged storage payment token used by the
   `Filecoin` IPFS provider (see [docs/docs/filecoin.md](../docs/filecoin)).
+- After bridging, USDfc is deposited into Filecoin Pay via
+  `depositWithPermit` (EIP-2612 permit, no prior ERC-20 approval needed).
+  First-time deposits also set max operator approval for the FWSS
+  storage contract in the same transaction.
 - Filecoin EVM chain ID is `314` (hex `0x13a`). Default RPC:
   `https://api.node.glif.io/rpc/v1`. Explorer: `https://filfox.info`.

--- a/docs/cli/topup.md
+++ b/docs/cli/topup.md
@@ -1,14 +1,23 @@
 # `omnipin topup`
 
-Bridge and deposit native tokens to a provider account. Currently supports
-AIOZ; Filecoin will follow.
+Bridge and deposit native tokens to a provider account. Supports **AIOZ**
+and **Filecoin**.
 
 ```sh
+# AIOZ: bridge native AIOZ from Ethereum or BSC into an AIOZ Network address.
 OMNIPIN_PK=0x... omnipin topup --provider=AIOZ --from-chain=eth <amount> --to=<address>
+
+# Filecoin: swap any supported source token into FIL (gas) + USDfc (storage).
+OMNIPIN_PK=0x... omnipin topup --provider=Filecoin \
+  --from-chain=arb --from-token=USDC <amount> --to=<filecoin_address>
 ```
 
-`<amount>` is the amount of AIOZ in whole tokens (e.g. `1.5`). It is parsed
-as an 18-decimal value.
+For AIOZ, `<amount>` is in whole AIOZ tokens (e.g. `1.5`, parsed as an
+18-decimal value).
+
+For Filecoin, `<amount>` is in `--from-token` units, decoded against the
+token's on-chain `decimals()` (e.g. `10` with `--from-token=USDC` means
+10 USDC).
 
 ## How it works (AIOZ)
 
@@ -33,46 +42,102 @@ mainnet for the optional forward step.
 
 ### `provider`
 
-Provider to top up. Currently only `AIOZ` is supported.
-
-```sh
-omnipin topup --provider=AIOZ ...
-```
+Provider to top up. One of `AIOZ` or `Filecoin`.
 
 ### `from-chain`
 
-Source chain for the bridge. One of `eth` or `bsc` — the two chains where
-AIOZ exists as an ERC-20 / BEP-20 token. Required when `--provider=AIOZ`.
+Source chain for the bridge.
+
+- **AIOZ:** `eth`, `bsc`.
+- **Filecoin:** `eth`, `opt`, `bsc`, `polygon`, `base`, `arb`, `avalanche`.
+
+### `from-token` (Filecoin only)
+
+Source token to spend on the bridge. Accepts either:
+
+- A known symbol on the source chain (e.g. `USDC`, `USDT`, `ETH`, `BNB`,
+  `MATIC`, `AVAX`, `WETH`, `USDC.e`), resolved against a per-chain table.
+- A raw `0x…` token address (escape hatch for anything not in the table).
 
 ### `to`
 
-Destination address on AIOZ Network (chain 168). Defaults to the signer's
-own address (derived from `OMNIPIN_PK`), in which case the forward step is
-skipped and the bridged funds simply land at the signer.
-
-For topping up an AIOZ-Pin account, pass the account's deposit address.
+- **AIOZ:** destination address on AIOZ Network (chain 168). Defaults to
+  the signer's own address.
+- **Filecoin:** destination address on Filecoin EVM (chain 314). Defaults
+  to the signer's own address.
 
 ### `rpc-url`
 
-Custom RPC endpoint for the source chain. Defaults to public nodes
-(`https://ethereum-rpc.publicnode.com` for `eth`,
-`https://bsc-dataseed.binance.org` for `bsc`).
+Custom RPC endpoint for the source chain. Defaults to public nodes.
 
 ### `aioz-rpc-url`
 
 Custom RPC endpoint for AIOZ Network (chain 168). Default:
 `https://eth-dataseed.aioz.network`.
 
+### `fil-ratio` (Filecoin only)
+
+Fraction in `[0, 1]` of `<amount>` to bridge into native FIL (gas). The
+rest goes to USDfc (storage payment). Default: `0.1` (10% FIL, 90% USDfc).
+
+### `slippage` (Filecoin only)
+
+Maximum acceptable slippage for the Squid swap legs, in percent. Default:
+`1`.
+
 ### `verbose`
 
 More verbose logs, including per-poll status updates from the relayer.
 
+## How it works (Filecoin)
+
+Filecoin top-ups go through [Squid Router](https://app.squidrouter.com),
+which wraps Axelar's cross-chain bridge with destination-side gas payment
+and an on-chain DEX swap on Filecoin (Sushiswap V3 against the
+`axlUSDC` / `USDfc` / `WFIL` pools). This means a single source-chain
+transaction can deliver native FIL **and** USDfc on Filecoin without the
+recipient needing FIL for destination gas.
+
+For each invocation:
+
+1. Two Squid `/v2/route` quotes are requested in parallel — one for
+   `<amount> * fil-ratio` → FIL, one for `<amount> * (1 - fil-ratio)` →
+   USDfc.
+2. If `--from-token` is an ERC-20, the Squid router is approved once for
+   the cumulative amount.
+3. The FIL leg is executed and polled on Squid's `/v2/status` until
+   `success`.
+4. The USDfc leg is executed and polled the same way.
+
+If Squid's API returns a non-2xx, the error includes a deeplink to the
+Squid web UI (`https://app.squidrouter.com/?chains=…&tokens=…`) preserving
+the requested parameters, so the user has a manual fallback path.
+
+### Squid integrator ID
+
+Omnipin uses the public `squid-swap-widget` integrator ID by default — the
+same identity the official Squid front-end at
+[v2.app.squidrouter.com](https://app.squidrouter.com) sends with every
+request. No registration required.
+
+Power users can override via `OMNIPIN_SQUID_INTEGRATOR_ID` to use their
+own integrator ID:
+
+```sh
+export OMNIPIN_SQUID_INTEGRATOR_ID=your-integrator-id
+```
+
+This is useful when running many top-ups from the same address (Squid
+rate-limits quote requests per `fromAddress`).
+
 ## Environment
 
-- `OMNIPIN_PK` — private key (hex, `0x`-prefixed) used to sign both the
-  source-chain `transfer` and the AIOZ-mainnet forward.
+- `OMNIPIN_PK` — private key (hex, `0x`-prefixed) used to sign all
+  source-chain transactions.
+- `OMNIPIN_SQUID_INTEGRATOR_ID` — optional Squid integrator ID
+  (Filecoin only).
 
-## Notes
+## Notes (AIOZ)
 
 - The bridge pool addresses are EOAs and can rotate. Omnipin always
   re-fetches them from `/swap-directions` before sending.
@@ -81,3 +146,14 @@ More verbose logs, including per-poll status updates from the relayer.
 - AIOZ Network may not be added to your wallet by default. Use chain ID
   `168` (hex `0xa8`), RPC `https://eth-dataseed.aioz.network`, explorer
   `https://explorer.aioz.network`.
+
+## Notes (Filecoin)
+
+- Bridge legs typically settle within 1–3 minutes. The poll waits up to
+  ~10 minutes per leg.
+- Squid's per-`fromAddress` quote rate limit can produce transient
+  errors during heavy use. Omnipin retries with exponential backoff.
+- USDfc is the canonical USD-pegged storage payment token used by the
+  `Filecoin` IPFS provider (see [docs/docs/filecoin.md](../docs/filecoin)).
+- Filecoin EVM chain ID is `314` (hex `0x13a`). Default RPC:
+  `https://api.node.glif.io/rpc/v1`. Explorer: `https://filfox.info`.

--- a/docs/cli/topup.md
+++ b/docs/cli/topup.md
@@ -49,7 +49,7 @@ Provider to top up. One of `AIOZ` or `Filecoin`.
 Source chain for the bridge.
 
 - **AIOZ:** `eth`, `bsc`.
-- **Filecoin:** `eth`, `opt`, `bsc`, `polygon`, `base`, `arb`, `avalanche`.
+- **Filecoin:** `eth`, `opt`, `bsc`, `polygon`, `base`, `arb`, `avax`.
 
 ### `from-token` (Filecoin only)
 

--- a/docs/cli/topup.md
+++ b/docs/cli/topup.md
@@ -143,7 +143,9 @@ rate-limits quote requests per `fromAddress`).
 - `OMNIPIN_SQUID_INTEGRATOR_ID` — optional Squid integrator ID
   (Filecoin only).
 
-## Notes (AIOZ)
+## Notes
+
+### AIOZ
 
 - The bridge pool addresses are EOAs and can rotate. Omnipin always
   re-fetches them from `/swap-directions` before sending.
@@ -153,7 +155,7 @@ rate-limits quote requests per `fromAddress`).
   `168` (hex `0xa8`), RPC `https://eth-dataseed.aioz.network`, explorer
   `https://explorer.aioz.network`.
 
-## Notes (Filecoin)
+### Filecoin
 
 - Bridge legs typically settle within 1–3 minutes. The poll waits up to
   ~10 minutes per leg.

--- a/src/actions/topup.ts
+++ b/src/actions/topup.ts
@@ -7,25 +7,32 @@ import {
   UnknownProviderError,
 } from '../errors.js'
 import {
-  SOURCE_CHAINS,
-  type SourceChain,
+  SOURCE_CHAINS as AIOZ_SOURCE_CHAINS,
+  type SourceChain as AiozSourceChain,
   topupAioz,
 } from '../utils/aioz-bridge.js'
+import {
+  isSourceChainKey as isFilecoinSourceChainKey,
+  topupFilecoin,
+} from '../utils/filecoin-topup.js'
 import { logger } from '../utils/logger.js'
 
 export type TopupActionArgs = Partial<{
   provider: string
   'from-chain': string
+  'from-token': string
   to: Address
   'rpc-url': string
   'aioz-rpc-url': string
+  'fil-ratio': string
+  slippage: string
   verbose: boolean
 }>
 
-const SUPPORTED_PROVIDERS = new Set(['AIOZ'])
+const SUPPORTED_PROVIDERS = new Set(['AIOZ', 'Filecoin'])
 
-const isSourceChain = (v: string | undefined): v is SourceChain =>
-  typeof v === 'string' && v in SOURCE_CHAINS
+const isAiozSourceChain = (v: string | undefined): v is AiozSourceChain =>
+  typeof v === 'string' && v in AIOZ_SOURCE_CHAINS
 
 export const topupAction = async ({
   amount,
@@ -46,7 +53,8 @@ export const topupAction = async ({
 
   if (provider === 'AIOZ') {
     const fromChain = options['from-chain']?.toLowerCase()
-    if (!isSourceChain(fromChain)) throw new MissingCLIArgsError(['from-chain'])
+    if (!isAiozSourceChain(fromChain))
+      throw new MissingCLIArgsError(['from-chain'])
 
     let amountWei: bigint
     try {
@@ -69,6 +77,50 @@ export const topupAction = async ({
     })
 
     logger.success('Top-up complete')
+    if (options.verbose) {
+      logger.text(JSON.stringify(result, null, 2))
+    }
+    return
+  }
+
+  if (provider === 'Filecoin') {
+    const fromChain = options['from-chain']?.toLowerCase()
+    if (!isFilecoinSourceChainKey(fromChain))
+      throw new MissingCLIArgsError(['from-chain'])
+
+    const fromToken = options['from-token']
+    if (!fromToken) throw new MissingCLIArgsError(['from-token'])
+
+    const filRatio =
+      options['fil-ratio'] !== undefined
+        ? Number.parseFloat(options['fil-ratio'])
+        : 0.1
+    if (!Number.isFinite(filRatio) || filRatio < 0 || filRatio > 1) {
+      throw new Error(
+        `--fil-ratio must be a number in [0, 1], got: ${options['fil-ratio']}`,
+      )
+    }
+
+    const slippage =
+      options.slippage !== undefined ? Number.parseFloat(options.slippage) : 1
+    if (!Number.isFinite(slippage) || slippage <= 0 || slippage > 50) {
+      throw new Error(
+        `--slippage must be a positive number ≤ 50 (percent), got: ${options.slippage}`,
+      )
+    }
+
+    const result = await topupFilecoin({
+      privateKey: pk,
+      fromChain,
+      fromToken,
+      amount,
+      to: options.to,
+      filRatio,
+      slippage,
+      sourceRpcUrl: options['rpc-url'],
+      verbose: options.verbose,
+    })
+
     if (options.verbose) {
       logger.text(JSON.stringify(result, null, 2))
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -284,7 +284,7 @@ cli.command<[string]>(
       {
         name: 'from-chain',
         description:
-          'Source chain for the bridge. AIOZ: eth, bsc. Filecoin: eth, opt, bsc, polygon, base, arb, avalanche.',
+          'Source chain for the bridge. AIOZ: eth, bsc. Filecoin: eth, opt, bsc, polygon, base, arb, avax.',
         type: 'string',
       },
       {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -278,12 +278,19 @@ cli.command<[string]>(
     options: [
       {
         name: 'provider',
-        description: 'Provider to top up (currently only AIOZ)',
+        description: 'Provider to top up (AIOZ or Filecoin)',
         type: 'string',
       },
       {
         name: 'from-chain',
-        description: 'Source chain for the bridge (eth or bsc, AIOZ only)',
+        description:
+          'Source chain for the bridge. AIOZ: eth, bsc. Filecoin: eth, opt, bsc, polygon, base, arb, avalanche.',
+        type: 'string',
+      },
+      {
+        name: 'from-token',
+        description:
+          'Source token symbol (USDC, ETH, USDT, …) or 0x address. Required for Filecoin.',
         type: 'string',
       },
       {
@@ -300,6 +307,18 @@ cli.command<[string]>(
       {
         name: 'aioz-rpc-url',
         description: 'Custom RPC for AIOZ mainnet (chain 168)',
+        type: 'string',
+      },
+      {
+        name: 'fil-ratio',
+        description:
+          'Fraction of the input split to FIL (rest to USDfc). Filecoin only. Default 0.1.',
+        type: 'string',
+      },
+      {
+        name: 'slippage',
+        description:
+          'Maximum acceptable slippage in percent for Squid swaps. Filecoin only. Default 1.',
         type: 'string',
       },
       {

--- a/src/utils/filecoin-topup.ts
+++ b/src/utils/filecoin-topup.ts
@@ -1,10 +1,3 @@
-import { encodeData } from 'ox/AbiFunction'
-import { type Address, fromPublicKey } from 'ox/Address'
-import { type Hex, toBigInt } from 'ox/Hex'
-import * as Provider from 'ox/Provider'
-import { fromHttp } from 'ox/RpcTransport'
-import { getPublicKey } from 'ox/Secp256k1'
-import * as Value from 'ox/Value'
 import {
   depositWithPermitAndApproveOperatorWriteParameters,
   depositWithPermitWriteParameters,
@@ -12,6 +5,14 @@ import {
   isFwssMaxApproved,
 } from '@omnipin/foc/fil-pay'
 import { filecoinMainnet, filProvider } from '@omnipin/foc/utils'
+import { encodeData } from 'ox/AbiFunction'
+import { type Address, fromPublicKey } from 'ox/Address'
+import { type Hex, toBigInt } from 'ox/Hex'
+import * as Provider from 'ox/Provider'
+import { fromHttp } from 'ox/RpcTransport'
+import { getPublicKey } from 'ox/Secp256k1'
+import * as Value from 'ox/Value'
+import { setTimeout } from '../deps.js'
 import { logger } from './logger.js'
 import {
   getRouteWithRetry,
@@ -21,7 +22,6 @@ import {
   type SquidRouteParams,
 } from './squid.js'
 import { sendTransaction, waitForTransaction } from './tx.js'
-import { setTimeout } from '../deps.js'
 
 /** Filecoin EVM mainnet (chain 314) constants. */
 export const FILECOIN_MAINNET = {
@@ -393,7 +393,7 @@ export const topupFilecoin = async ({
   const isNative = sourceToken.toLowerCase() === NATIVE_TOKEN.toLowerCase()
   if (!isNative) {
     const spender = (filRoute?.transactionRequest.target ??
-      usdfcRoute!.transactionRequest.target) as Address
+      usdfcRoute?.transactionRequest.target) as Address
     await ensureAllowance({
       provider,
       privateKey,
@@ -497,9 +497,7 @@ export const topupFilecoin = async ({
       privateKey,
     })) as Hex
 
-    logger.info(
-      `Deposit tx: ${FILECOIN_MAINNET.explorer}/tx/${depositHash}`,
-    )
+    logger.info(`Deposit tx: ${FILECOIN_MAINNET.explorer}/tx/${depositHash}`)
 
     await waitForTransaction(filProvider[filecoinMainnet.id], depositHash)
     logger.success('Deposit confirmed')

--- a/src/utils/filecoin-topup.ts
+++ b/src/utils/filecoin-topup.ts
@@ -52,7 +52,7 @@ export type SourceChainKey =
   | 'polygon'
   | 'base'
   | 'arb'
-  | 'avalanche'
+  | 'avax'
 
 type ChainConfig = {
   id: SourceChainId
@@ -139,7 +139,7 @@ export const SOURCE_CHAINS: Record<SourceChainKey, ChainConfig> = {
       USDT: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
     },
   },
-  avalanche: {
+  avax: {
     id: 43114,
     name: 'Avalanche',
     rpc: 'https://avalanche-c-chain-rpc.publicnode.com',

--- a/src/utils/filecoin-topup.ts
+++ b/src/utils/filecoin-topup.ts
@@ -1,0 +1,495 @@
+import { encodeData } from 'ox/AbiFunction'
+import { type Address, fromPublicKey } from 'ox/Address'
+import { type Hex, toBigInt } from 'ox/Hex'
+import * as Provider from 'ox/Provider'
+import { fromHttp } from 'ox/RpcTransport'
+import { getPublicKey } from 'ox/Secp256k1'
+import * as Value from 'ox/Value'
+import { logger } from './logger.js'
+import {
+  getRouteWithRetry,
+  NATIVE_TOKEN,
+  pollSquidStatus,
+  type SquidRoute,
+  type SquidRouteParams,
+} from './squid.js'
+import { sendTransaction, waitForTransaction } from './tx.js'
+
+/** Filecoin EVM mainnet (chain 314) constants. */
+export const FILECOIN_MAINNET = {
+  id: 314,
+  name: 'Filecoin',
+  rpc: 'https://api.node.glif.io/rpc/v1',
+  explorer: 'https://filfox.info/en',
+} as const
+
+/** USDfc on Filecoin (the canonical USD-pegged storage payment token). */
+export const FILECOIN_USDFC: Address =
+  '0x80b98d3aa09ffff255c3ba4a241111ff1262f045'
+
+/** axlUSDC on Filecoin (where Axelar bridges land USDC). */
+export const FILECOIN_AXL_USDC: Address =
+  '0xeb466342c4d449bc9f53a865d5cb90586f405215'
+
+/** WFIL on Filecoin. */
+export const FILECOIN_WFIL: Address =
+  '0x60e1773636cf5e4a227d9ac24f20feca034ee25a'
+
+export type SourceChainId = 1 | 10 | 56 | 137 | 8453 | 42161 | 43114
+
+export type SourceChainKey =
+  | 'eth'
+  | 'opt'
+  | 'bsc'
+  | 'polygon'
+  | 'base'
+  | 'arb'
+  | 'avalanche'
+
+type ChainConfig = {
+  id: SourceChainId
+  name: string
+  rpc: string
+  explorer: string
+  /** Symbol → ERC-20 address (or NATIVE_TOKEN sentinel). */
+  tokens: Record<string, Address>
+}
+
+export const SOURCE_CHAINS: Record<SourceChainKey, ChainConfig> = {
+  eth: {
+    id: 1,
+    name: 'Ethereum',
+    rpc: 'https://ethereum-rpc.publicnode.com',
+    explorer: 'https://etherscan.io',
+    tokens: {
+      ETH: NATIVE_TOKEN,
+      WETH: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      USDC: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      USDT: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+      DAI: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+    },
+  },
+  opt: {
+    id: 10,
+    name: 'Optimism',
+    rpc: 'https://optimism-rpc.publicnode.com',
+    explorer: 'https://optimistic.etherscan.io',
+    tokens: {
+      ETH: NATIVE_TOKEN,
+      WETH: '0x4200000000000000000000000000000000000006',
+      USDC: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
+      USDT: '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58',
+    },
+  },
+  bsc: {
+    id: 56,
+    name: 'BNB Smart Chain',
+    rpc: 'https://bsc-rpc.publicnode.com',
+    explorer: 'https://bscscan.com',
+    tokens: {
+      BNB: NATIVE_TOKEN,
+      WBNB: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+      USDC: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
+      USDT: '0x55d398326f99059fF775485246999027B3197955',
+    },
+  },
+  polygon: {
+    id: 137,
+    name: 'Polygon',
+    rpc: 'https://polygon-bor-rpc.publicnode.com',
+    explorer: 'https://polygonscan.com',
+    tokens: {
+      POL: NATIVE_TOKEN,
+      MATIC: NATIVE_TOKEN,
+      WETH: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
+      USDC: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+      'USDC.e': '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+      USDT: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+    },
+  },
+  base: {
+    id: 8453,
+    name: 'Base',
+    rpc: 'https://base-rpc.publicnode.com',
+    explorer: 'https://basescan.org',
+    tokens: {
+      ETH: NATIVE_TOKEN,
+      WETH: '0x4200000000000000000000000000000000000006',
+      USDC: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    },
+  },
+  arb: {
+    id: 42161,
+    name: 'Arbitrum',
+    rpc: 'https://arbitrum-one-rpc.publicnode.com',
+    explorer: 'https://arbiscan.io',
+    tokens: {
+      ETH: NATIVE_TOKEN,
+      WETH: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
+      USDC: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+      'USDC.e': '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
+      USDT: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+    },
+  },
+  avalanche: {
+    id: 43114,
+    name: 'Avalanche',
+    rpc: 'https://avalanche-c-chain-rpc.publicnode.com',
+    explorer: 'https://snowtrace.io',
+    tokens: {
+      AVAX: NATIVE_TOKEN,
+      WAVAX: '0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7',
+      USDC: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
+      USDT: '0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7',
+    },
+  },
+}
+
+export const isSourceChainKey = (v: string | undefined): v is SourceChainKey =>
+  typeof v === 'string' && v in SOURCE_CHAINS
+
+const erc20Approve = {
+  name: 'approve',
+  type: 'function',
+  stateMutability: 'nonpayable',
+  inputs: [
+    { name: 'spender', type: 'address' },
+    { name: 'amount', type: 'uint256' },
+  ],
+  outputs: [{ type: 'bool' }],
+} as const
+
+const erc20Allowance = {
+  name: 'allowance',
+  type: 'function',
+  stateMutability: 'view',
+  inputs: [
+    { name: 'owner', type: 'address' },
+    { name: 'spender', type: 'address' },
+  ],
+  outputs: [{ type: 'uint256' }],
+} as const
+
+const erc20Decimals = {
+  name: 'decimals',
+  type: 'function',
+  stateMutability: 'view',
+  inputs: [],
+  outputs: [{ type: 'uint8' }],
+} as const
+
+/**
+ * Resolve `--from-token` (either a known symbol on the given chain, or a raw
+ * 0x address) to an ERC-20 contract address. Throws when the symbol is
+ * unknown for the chain.
+ */
+export const resolveSourceToken = ({
+  chain,
+  token,
+}: {
+  chain: SourceChainKey
+  token: string
+}): Address => {
+  if (token.startsWith('0x') && token.length === 42) {
+    return token as Address
+  }
+  const upper = token.toUpperCase()
+  const chainConfig = SOURCE_CHAINS[chain]
+  // Allow case-insensitive symbol lookup including dotted symbols like USDC.e.
+  for (const [sym, addr] of Object.entries(chainConfig.tokens)) {
+    if (sym.toUpperCase() === upper) return addr
+  }
+  throw new Error(
+    `Unknown token "${token}" on ${chainConfig.name}. Known symbols: ${Object.keys(
+      chainConfig.tokens,
+    ).join(', ')}. Or pass a raw 0x address.`,
+  )
+}
+
+/** Read on-chain decimals for an ERC-20, or return 18 for the native sentinel. */
+const fetchTokenDecimals = async ({
+  provider,
+  token,
+}: {
+  provider: Provider.Provider
+  token: Address
+}): Promise<number> => {
+  if (token.toLowerCase() === NATIVE_TOKEN.toLowerCase()) return 18
+  const raw = await provider.request({
+    method: 'eth_call',
+    params: [{ to: token, data: encodeData(erc20Decimals) }, 'latest'],
+  })
+  // decimals() returns uint8 padded to 32 bytes.
+  return Number(toBigInt(raw as Hex))
+}
+
+/** Ensure the Squid router has an allowance >= amount; approve max if not. */
+const ensureAllowance = async ({
+  provider,
+  privateKey,
+  owner,
+  token,
+  spender,
+  amount,
+  chainId,
+}: {
+  provider: Provider.Provider
+  privateKey: Hex
+  owner: Address
+  token: Address
+  spender: Address
+  amount: bigint
+  chainId: number
+}): Promise<void> => {
+  const raw = await provider.request({
+    method: 'eth_call',
+    params: [
+      { to: token, data: encodeData(erc20Allowance, [owner, spender]) },
+      'latest',
+    ],
+  })
+  const current = toBigInt(raw as Hex)
+  if (current >= amount) return
+
+  logger.info(`Approving ${spender} to spend the source token`)
+  // Approve max uint256 once to avoid repeated approvals for split topups.
+  const max = 2n ** 256n - 1n
+  const data = encodeData(erc20Approve, [spender, max])
+  const txHash = (await sendTransaction({
+    provider,
+    chainId,
+    privateKey,
+    to: token,
+    data,
+    from: owner,
+  })) as Hex
+  await waitForTransaction(provider, txHash)
+}
+
+export type FilecoinTopupResult = {
+  /** Source-chain transaction that triggered the USDfc bridge leg. */
+  usdfcTxHash?: Hex
+  /** Source-chain transaction that triggered the FIL bridge leg. */
+  filTxHash?: Hex
+  /** Squid status response for each leg. */
+  usdfcStatus?: unknown
+  filStatus?: unknown
+}
+
+/**
+ * Top up Filecoin: bridge a portion of the input token to native FIL (gas)
+ * and the rest to USDfc (storage payment) via Squid Router.
+ */
+export const topupFilecoin = async ({
+  privateKey,
+  fromChain,
+  fromToken,
+  amount,
+  to,
+  filRatio,
+  slippage,
+  sourceRpcUrl,
+  verbose,
+}: {
+  privateKey: Hex
+  fromChain: SourceChainKey
+  fromToken: string
+  amount: string
+  to?: Address
+  /** Fraction in [0, 1] of the input value sent to FIL. Rest goes to USDfc. */
+  filRatio: number
+  /** Slippage in percent (Squid expects integer; 1 = 1%). */
+  slippage: number
+  sourceRpcUrl?: string
+  verbose?: boolean
+}): Promise<FilecoinTopupResult> => {
+  if (filRatio < 0 || filRatio > 1) {
+    throw new Error(`--fil-ratio must be in [0, 1], got ${filRatio}`)
+  }
+
+  const signer = fromPublicKey(getPublicKey({ privateKey }))
+  const destination = (to ?? signer) as Address
+
+  const chainConfig = SOURCE_CHAINS[fromChain]
+  const sourceToken = resolveSourceToken({ chain: fromChain, token: fromToken })
+
+  const transport = fromHttp(sourceRpcUrl ?? chainConfig.rpc)
+  const provider = Provider.from(transport)
+
+  const decimals = await fetchTokenDecimals({ provider, token: sourceToken })
+  let totalAmountAtomic: bigint
+  try {
+    totalAmountAtomic = Value.from(amount, decimals)
+  } catch {
+    throw new Error(`Invalid amount: ${amount}`)
+  }
+  if (totalAmountAtomic <= 0n)
+    throw new Error(`Amount must be positive: ${amount}`)
+
+  // Compute the per-leg amounts. We scale via a 1e6 fixed-point ratio to
+  // avoid floating-point sloppiness in the split arithmetic.
+  const ratioBp = Math.round(filRatio * 1_000_000)
+  const filAtomic = (totalAmountAtomic * BigInt(ratioBp)) / 1_000_000n
+  const usdfcAtomic = totalAmountAtomic - filAtomic
+
+  logger.start(
+    `Top-up Filecoin: ${amount} ${fromToken} from ${chainConfig.name} → ${destination}`,
+  )
+  logger.info(
+    `Split: ${filAtomic} (FIL leg) + ${usdfcAtomic} (USDfc leg), source-token atomic units`,
+  )
+
+  // Quote both legs ahead of time so we surface route errors before any
+  // on-chain action.
+  const filParams: SquidRouteParams | undefined =
+    filAtomic > 0n
+      ? {
+          fromAddress: signer,
+          fromChain: chainConfig.id,
+          fromToken: sourceToken,
+          fromAmount: filAtomic.toString(),
+          toChain: FILECOIN_MAINNET.id,
+          toToken: NATIVE_TOKEN,
+          toAddress: destination,
+          slippage,
+        }
+      : undefined
+
+  const usdfcParams: SquidRouteParams | undefined =
+    usdfcAtomic > 0n
+      ? {
+          fromAddress: signer,
+          fromChain: chainConfig.id,
+          fromToken: sourceToken,
+          fromAmount: usdfcAtomic.toString(),
+          toChain: FILECOIN_MAINNET.id,
+          toToken: FILECOIN_USDFC,
+          toAddress: destination,
+          slippage,
+        }
+      : undefined
+
+  const filRoute = filParams
+    ? await getRouteWithRetry({ params: filParams })
+    : undefined
+  const usdfcRoute = usdfcParams
+    ? await getRouteWithRetry({ params: usdfcParams })
+    : undefined
+
+  if (verbose) {
+    if (filRoute) logRouteSummary('FIL', filRoute)
+    if (usdfcRoute) logRouteSummary('USDfc', usdfcRoute)
+  }
+
+  // For ERC-20 inputs, approve the Squid router for the *total* once.
+  const isNative = sourceToken.toLowerCase() === NATIVE_TOKEN.toLowerCase()
+  if (!isNative) {
+    const spender = (filRoute?.transactionRequest.target ??
+      usdfcRoute!.transactionRequest.target) as Address
+    await ensureAllowance({
+      provider,
+      privateKey,
+      owner: signer,
+      token: sourceToken,
+      spender,
+      amount: totalAmountAtomic,
+      chainId: chainConfig.id,
+    })
+  }
+
+  const result: FilecoinTopupResult = {}
+
+  if (filRoute && filParams) {
+    logger.info(`Executing FIL leg on ${chainConfig.name}`)
+    const txHash = await executeRoute({
+      provider,
+      privateKey,
+      chainId: chainConfig.id,
+      signer,
+      route: filRoute,
+    })
+    logger.info(`FIL leg tx: ${chainConfig.explorer}/tx/${txHash}`)
+    await waitForTransaction(provider, txHash)
+    logger.info('FIL leg source tx confirmed; polling relayer…')
+    const status = await pollSquidStatus({
+      transactionId: txHash,
+      requestId: filRoute.params?.requestId,
+      fromChainId: chainConfig.id,
+      toChainId: FILECOIN_MAINNET.id,
+      onAttempt: (n, s) => {
+        if (verbose) logger.info(`  FIL poll #${n}: status=${s ?? '<none>'}`)
+      },
+    })
+    logger.success('FIL leg bridged')
+    result.filTxHash = txHash
+    result.filStatus = status
+  }
+
+  if (usdfcRoute && usdfcParams) {
+    logger.info(`Executing USDfc leg on ${chainConfig.name}`)
+    const txHash = await executeRoute({
+      provider,
+      privateKey,
+      chainId: chainConfig.id,
+      signer,
+      route: usdfcRoute,
+    })
+    logger.info(`USDfc leg tx: ${chainConfig.explorer}/tx/${txHash}`)
+    await waitForTransaction(provider, txHash)
+    logger.info('USDfc leg source tx confirmed; polling relayer…')
+    const status = await pollSquidStatus({
+      transactionId: txHash,
+      requestId: usdfcRoute.params?.requestId,
+      fromChainId: chainConfig.id,
+      toChainId: FILECOIN_MAINNET.id,
+      onAttempt: (n, s) => {
+        if (verbose) logger.info(`  USDfc poll #${n}: status=${s ?? '<none>'}`)
+      },
+    })
+    logger.success('USDfc leg bridged')
+    result.usdfcTxHash = txHash
+    result.usdfcStatus = status
+  }
+
+  logger.success('Filecoin top-up complete')
+  return result
+}
+
+const executeRoute = async ({
+  provider,
+  privateKey,
+  chainId,
+  signer,
+  route,
+}: {
+  provider: Provider.Provider
+  privateKey: Hex
+  chainId: number
+  signer: Address
+  route: SquidRoute
+}): Promise<Hex> => {
+  const tx = route.transactionRequest
+  const value = tx.value ? BigInt(tx.value) : 0n
+  return (await sendTransaction({
+    provider,
+    chainId,
+    privateKey,
+    to: tx.target,
+    data: tx.data,
+    from: signer,
+    value,
+  })) as Hex
+}
+
+const logRouteSummary = (label: string, route: SquidRoute) => {
+  const est = route.estimate
+  const actions = (est.actions ?? [])
+    .map(
+      (a) =>
+        `${a.type}(${a.fromToken?.symbol ?? '?'} → ${a.toToken?.symbol ?? '?'})`,
+    )
+    .join(' / ')
+  logger.info(
+    `  ${label}: $${est.fromAmountUSD} → $${est.toAmountUSD} (${est.estimatedRouteDuration}s) [${actions}]`,
+  )
+}

--- a/src/utils/filecoin-topup.ts
+++ b/src/utils/filecoin-topup.ts
@@ -5,6 +5,13 @@ import * as Provider from 'ox/Provider'
 import { fromHttp } from 'ox/RpcTransport'
 import { getPublicKey } from 'ox/Secp256k1'
 import * as Value from 'ox/Value'
+import {
+  depositWithPermitAndApproveOperatorWriteParameters,
+  depositWithPermitWriteParameters,
+  getUSDfcBalance,
+  isFwssMaxApproved,
+} from '@omnipin/foc/fil-pay'
+import { filecoinMainnet, filProvider } from '@omnipin/foc/utils'
 import { logger } from './logger.js'
 import {
   getRouteWithRetry,
@@ -14,6 +21,7 @@ import {
   type SquidRouteParams,
 } from './squid.js'
 import { sendTransaction, waitForTransaction } from './tx.js'
+import { setTimeout } from '../deps.js'
 
 /** Filecoin EVM mainnet (chain 314) constants. */
 export const FILECOIN_MAINNET = {
@@ -345,10 +353,10 @@ export const topupFilecoin = async ({
     filAtomic > 0n
       ? {
           fromAddress: signer,
-          fromChain: chainConfig.id,
+          fromChain: String(chainConfig.id),
           fromToken: sourceToken,
           fromAmount: filAtomic.toString(),
-          toChain: FILECOIN_MAINNET.id,
+          toChain: String(FILECOIN_MAINNET.id),
           toToken: NATIVE_TOKEN,
           toAddress: destination,
           slippage,
@@ -359,10 +367,10 @@ export const topupFilecoin = async ({
     usdfcAtomic > 0n
       ? {
           fromAddress: signer,
-          fromChain: chainConfig.id,
+          fromChain: String(chainConfig.id),
           fromToken: sourceToken,
           fromAmount: usdfcAtomic.toString(),
-          toChain: FILECOIN_MAINNET.id,
+          toChain: String(FILECOIN_MAINNET.id),
           toToken: FILECOIN_USDFC,
           toAddress: destination,
           slippage,
@@ -414,8 +422,8 @@ export const topupFilecoin = async ({
     const status = await pollSquidStatus({
       transactionId: txHash,
       requestId: filRoute.params?.requestId,
-      fromChainId: chainConfig.id,
-      toChainId: FILECOIN_MAINNET.id,
+      fromChainId: String(chainConfig.id),
+      toChainId: String(FILECOIN_MAINNET.id),
       onAttempt: (n, s) => {
         if (verbose) logger.info(`  FIL poll #${n}: status=${s ?? '<none>'}`)
       },
@@ -440,8 +448,8 @@ export const topupFilecoin = async ({
     const status = await pollSquidStatus({
       transactionId: txHash,
       requestId: usdfcRoute.params?.requestId,
-      fromChainId: chainConfig.id,
-      toChainId: FILECOIN_MAINNET.id,
+      fromChainId: String(chainConfig.id),
+      toChainId: String(FILECOIN_MAINNET.id),
       onAttempt: (n, s) => {
         if (verbose) logger.info(`  USDfc poll #${n}: status=${s ?? '<none>'}`)
       },
@@ -449,6 +457,52 @@ export const topupFilecoin = async ({
     logger.success('USDfc leg bridged')
     result.usdfcTxHash = txHash
     result.usdfcStatus = status
+  }
+
+  // Deposit bridged USDfc to Filecoin Pay
+  if (usdfcAtomic > 0n) {
+    logger.info('Waiting for USDfc balance to arrive on Filecoin…')
+    const usdfcBalance = await waitForUsdfcBalance({
+      address: destination,
+      minimumWei: usdfcAtomic,
+      verbose,
+    })
+
+    logger.info(
+      `Depositing ${Value.format(usdfcBalance, 18)} USDfc to Filecoin Pay`,
+    )
+
+    const alreadyApproved = await isFwssMaxApproved({
+      clientAddress: destination,
+      chain: filecoinMainnet,
+    })
+
+    const params = alreadyApproved
+      ? await depositWithPermitWriteParameters({
+          privateKey,
+          address: destination,
+          amount: usdfcBalance,
+          chain: filecoinMainnet,
+        })
+      : await depositWithPermitAndApproveOperatorWriteParameters({
+          privateKey,
+          address: destination,
+          amount: usdfcBalance,
+          chain: filecoinMainnet,
+        })
+
+    const depositHash = (await sendTransaction({
+      ...params,
+      chainId: filecoinMainnet.id,
+      privateKey,
+    })) as Hex
+
+    logger.info(
+      `Deposit tx: ${FILECOIN_MAINNET.explorer}/tx/${depositHash}`,
+    )
+
+    await waitForTransaction(filProvider[filecoinMainnet.id], depositHash)
+    logger.success('Deposit confirmed')
   }
 
   logger.success('Filecoin top-up complete')
@@ -491,5 +545,42 @@ const logRouteSummary = (label: string, route: SquidRoute) => {
     .join(' / ')
   logger.info(
     `  ${label}: $${est.fromAmountUSD} → $${est.toAmountUSD} (${est.estimatedRouteDuration}s) [${actions}]`,
+  )
+}
+
+/**
+ * Poll Filecoin RPC until the address's USDfc balance reaches at least
+ * `minimumWei`. The Squid relayer reports `success` as soon as the
+ * destination tx is mined, but some RPC providers lag by a few seconds
+ * before exposing the new balance.
+ */
+const waitForUsdfcBalance = async ({
+  address,
+  minimumWei,
+  maxAttempts = 60,
+  intervalMs = 10_000,
+  verbose,
+}: {
+  address: Address
+  minimumWei: bigint
+  maxAttempts?: number
+  intervalMs?: number
+  verbose?: boolean
+}): Promise<bigint> => {
+  for (let i = 0; i < maxAttempts; i++) {
+    const balance = await getUSDfcBalance({
+      address,
+      chain: filecoinMainnet,
+    })
+    if (balance >= minimumWei) return balance
+    if (verbose && i % 5 === 0) {
+      logger.info(
+        `Waiting for USDfc balance (have ${Value.format(balance, 18)}, need ${Value.format(minimumWei, 18)})`,
+      )
+    }
+    await setTimeout(intervalMs)
+  }
+  throw new Error(
+    `USDfc balance did not reach ${Value.format(minimumWei, 18)} within ${maxAttempts} polls`,
   )
 }

--- a/src/utils/squid.ts
+++ b/src/utils/squid.ts
@@ -1,0 +1,293 @@
+import type { Address } from 'ox/Address'
+import type { Hex } from 'ox/Hex'
+import { setTimeout } from '../deps.js'
+import { logger } from './logger.js'
+
+export const SQUID_API = 'https://v2.api.squidrouter.com'
+
+/**
+ * Default integrator ID is the public Squid widget identity, the same one
+ * the official Squid front-end at v2.app.squidrouter.com sends with every
+ * request. No registration required; works out of the box.
+ *
+ * Power users with their own Squid integrator ID can override via the
+ * `OMNIPIN_SQUID_INTEGRATOR_ID` environment variable for higher rate limits
+ * and resilience against widget-ID throttling.
+ */
+export const getIntegratorId = (): string =>
+  process.env.OMNIPIN_SQUID_INTEGRATOR_ID || 'squid-swap-widget'
+
+/** Native asset sentinel used by Squid for chain-native gas tokens. */
+export const NATIVE_TOKEN: Address =
+  '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+
+export type SquidRouteParams = {
+  fromAddress: Address
+  fromChain: string | number
+  fromToken: Address
+  fromAmount: string
+  toChain: string | number
+  toToken: Address
+  toAddress: Address
+  slippage: number
+  enableExpress?: boolean
+}
+
+export type SquidTransactionRequest = {
+  target: Address
+  data: Hex
+  value: string
+  gasLimit?: string
+  maxFeePerGas?: string
+  maxPriorityFeePerGas?: string
+  gasPrice?: string
+  requestId?: string
+  expiry?: number
+  expiryOffset?: number
+}
+
+export type SquidAction = {
+  type: string
+  fromToken?: { symbol?: string }
+  toToken?: { symbol?: string }
+  provider?: string
+}
+
+export type SquidEstimate = {
+  fromAmount?: string
+  toAmount?: string
+  toAmountMin?: string
+  fromAmountUSD?: string
+  toAmountUSD?: string
+  estimatedRouteDuration?: number
+  actions?: SquidAction[]
+}
+
+export type SquidRoute = {
+  estimate: SquidEstimate
+  transactionRequest: SquidTransactionRequest
+  params?: { requestId?: string }
+}
+
+export type SquidRouteResponse = {
+  route: SquidRoute
+}
+
+/**
+ * Fetch a Squid route quote. Throws a descriptive error when Squid replies
+ * with a non-2xx status, embedding a deeplink to the Squid web UI so the
+ * user has a manual fallback path during API outages.
+ */
+export const getRoute = async ({
+  params,
+  integratorId = getIntegratorId(),
+  fetchFn = fetch,
+  requestId,
+}: {
+  params: SquidRouteParams
+  integratorId?: string
+  fetchFn?: typeof fetch
+  /** Optional opaque trace ID returned in `x-request-id` response header. */
+  requestId?: { value?: string }
+}): Promise<SquidRoute> => {
+  const res = await fetchFn(`${SQUID_API}/v2/route`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-integrator-id': integratorId,
+    },
+    body: JSON.stringify(params),
+  })
+
+  if (requestId) {
+    requestId.value =
+      res.headers.get('x-request-id') ||
+      res.headers.get('x-request-id-load-balancer') ||
+      undefined
+  }
+
+  if (!res.ok) {
+    let message: string | undefined
+    try {
+      const body = (await res.json()) as { message?: string; error?: string }
+      message = body.message || body.error
+    } catch {}
+
+    const webUi = squidWebUiUrl(params)
+    throw new Error(
+      `Squid quote failed (${res.status}): ${
+        message ?? res.statusText
+      }. Fallback: ${webUi}`,
+    )
+  }
+
+  const body = (await res.json()) as SquidRouteResponse
+  if (!body.route) {
+    throw new Error('Squid returned an empty route response')
+  }
+  return body.route
+}
+
+/** Build a deeplink to the Squid web UI mirroring the CLI's request. */
+export const squidWebUiUrl = (params: SquidRouteParams): string => {
+  const u = new URL('https://app.squidrouter.com')
+  u.searchParams.set('chains', `${params.fromChain},${params.toChain}`)
+  u.searchParams.set('tokens', `${params.fromToken},${params.toToken}`)
+  return u.toString()
+}
+
+/**
+ * Squid `/v2/status` response. `squidTransactionStatus` is the terminal
+ * indicator; `ongoing` means keep polling, everything else is terminal.
+ */
+export type SquidStatusResponse = {
+  squidTransactionStatus?: string
+  status?: string
+  toChain?: { transactionId?: string }
+}
+
+/** Terminal statuses per Squid docs (anything other than `ongoing`). */
+const TERMINAL_STATUSES = new Set([
+  'success',
+  'partial_success',
+  'needs_gas',
+  'not_found',
+  'refund',
+])
+
+export const getStatus = async ({
+  transactionId,
+  requestId,
+  fromChainId,
+  toChainId,
+  integratorId = getIntegratorId(),
+  fetchFn = fetch,
+}: {
+  transactionId: Hex
+  requestId?: string
+  fromChainId: string | number
+  toChainId: string | number
+  integratorId?: string
+  fetchFn?: typeof fetch
+}): Promise<SquidStatusResponse> => {
+  const url = new URL(`${SQUID_API}/v2/status`)
+  url.searchParams.set('transactionId', transactionId)
+  if (requestId) url.searchParams.set('requestId', requestId)
+  url.searchParams.set('fromChainId', String(fromChainId))
+  url.searchParams.set('toChainId', String(toChainId))
+
+  const res = await fetchFn(url.toString(), {
+    headers: { 'x-integrator-id': integratorId },
+  })
+
+  if (res.status === 404) {
+    // Relayer hasn't indexed the source tx yet — treat as ongoing.
+    return { squidTransactionStatus: 'ongoing' }
+  }
+  if (!res.ok) {
+    throw new Error(`Squid /v2/status returned ${res.status} ${res.statusText}`)
+  }
+  return (await res.json()) as SquidStatusResponse
+}
+
+/**
+ * Poll Squid `/v2/status` until the cross-chain swap reaches a terminal
+ * state. Resolves on `success` / `partial_success`, throws otherwise.
+ */
+export const pollSquidStatus = async ({
+  transactionId,
+  requestId,
+  fromChainId,
+  toChainId,
+  maxAttempts = 60,
+  intervalMs = 10_000,
+  warmupAttempts = 6,
+  onAttempt,
+  fetchFn = fetch,
+  integratorId = getIntegratorId(),
+}: {
+  transactionId: Hex
+  requestId?: string
+  fromChainId: string | number
+  toChainId: string | number
+  maxAttempts?: number
+  intervalMs?: number
+  warmupAttempts?: number
+  onAttempt?: (attempt: number, status: string | null) => void
+  fetchFn?: typeof fetch
+  integratorId?: string
+}): Promise<SquidStatusResponse> => {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let response: SquidStatusResponse | undefined
+    let status: string | null = null
+    try {
+      response = await getStatus({
+        transactionId,
+        requestId,
+        fromChainId,
+        toChainId,
+        fetchFn,
+        integratorId,
+      })
+      status = response.squidTransactionStatus ?? null
+    } catch (e) {
+      // Tolerate transient errors during the warm-up window.
+      if (attempt > warmupAttempts) throw e
+    }
+
+    onAttempt?.(attempt, status)
+
+    if (status && TERMINAL_STATUSES.has(status)) {
+      if (status === 'success' || status === 'partial_success') {
+        return response!
+      }
+      throw new Error(
+        `Squid bridge ended in non-success state: ${status} (axelarscan: https://axelarscan.io/gmp/${transactionId})`,
+      )
+    }
+
+    if (attempt < maxAttempts) await setTimeout(intervalMs)
+  }
+
+  throw new Error(
+    `Squid bridge poll timed out after ${maxAttempts} attempts for tx ${transactionId}`,
+  )
+}
+
+/**
+ * Retrying wrapper around `getRoute`. Handles Squid's per-address quote
+ * rate limit (responds with `error: "Too many quote requests for this
+ * address"` and a `retryAfter` field) by waiting and retrying.
+ */
+export const getRouteWithRetry = async ({
+  params,
+  attempts = 3,
+  initialDelayMs = 5_000,
+  fetchFn = fetch,
+  integratorId = getIntegratorId(),
+}: {
+  params: SquidRouteParams
+  attempts?: number
+  initialDelayMs?: number
+  fetchFn?: typeof fetch
+  integratorId?: string
+}): Promise<SquidRoute> => {
+  let lastErr: unknown
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await getRoute({ params, integratorId, fetchFn })
+    } catch (e) {
+      lastErr = e
+      const msg = (e as Error).message || ''
+      if (msg.includes('Too many quote requests')) {
+        const delay = initialDelayMs * 2 ** i
+        logger.warn(`Squid rate-limited; retrying in ${delay}ms`)
+        await setTimeout(delay)
+        continue
+      }
+      // Non-retryable: surface immediately.
+      throw e
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error('Squid retry exhausted')
+}

--- a/src/utils/squid.ts
+++ b/src/utils/squid.ts
@@ -23,10 +23,10 @@ export const NATIVE_TOKEN: Address =
 
 export type SquidRouteParams = {
   fromAddress: Address
-  fromChain: string | number
+  fromChain: string
   fromToken: Address
   fromAmount: string
-  toChain: string | number
+  toChain: string
   toToken: Address
   toAddress: Address
   slippage: number
@@ -165,8 +165,8 @@ export const getStatus = async ({
 }: {
   transactionId: Hex
   requestId?: string
-  fromChainId: string | number
-  toChainId: string | number
+  fromChainId: string
+  toChainId: string
   integratorId?: string
   fetchFn?: typeof fetch
 }): Promise<SquidStatusResponse> => {
@@ -208,8 +208,8 @@ export const pollSquidStatus = async ({
 }: {
   transactionId: Hex
   requestId?: string
-  fromChainId: string | number
-  toChainId: string | number
+  fromChainId: string
+  toChainId: string
   maxAttempts?: number
   intervalMs?: number
   warmupAttempts?: number

--- a/test/actions/topup.test.ts
+++ b/test/actions/topup.test.ts
@@ -91,4 +91,100 @@ describe('topup action', () => {
       }),
     ).rejects.toThrow(/Invalid amount/)
   })
+
+  describe('Filecoin', () => {
+    it('throws MissingCLIArgsError if --from-chain is missing', async () => {
+      process.env.OMNIPIN_PK = DUMMY_PK
+      await expect(
+        topupAction({
+          amount: '1',
+          options: { provider: 'Filecoin', 'from-token': 'USDC' },
+        }),
+      ).rejects.toBeInstanceOf(MissingCLIArgsError)
+    })
+
+    it('throws MissingCLIArgsError for an unsupported --from-chain', async () => {
+      process.env.OMNIPIN_PK = DUMMY_PK
+      await expect(
+        topupAction({
+          amount: '1',
+          options: {
+            provider: 'Filecoin',
+            'from-chain': 'fantom',
+            'from-token': 'USDC',
+          },
+        }),
+      ).rejects.toBeInstanceOf(MissingCLIArgsError)
+    })
+
+    it('throws MissingCLIArgsError if --from-token is missing', async () => {
+      process.env.OMNIPIN_PK = DUMMY_PK
+      await expect(
+        topupAction({
+          amount: '1',
+          options: { provider: 'Filecoin', 'from-chain': 'arb' },
+        }),
+      ).rejects.toBeInstanceOf(MissingCLIArgsError)
+    })
+
+    it('rejects an out-of-range --fil-ratio', async () => {
+      process.env.OMNIPIN_PK = DUMMY_PK
+      await expect(
+        topupAction({
+          amount: '1',
+          options: {
+            provider: 'Filecoin',
+            'from-chain': 'arb',
+            'from-token': 'USDC',
+            'fil-ratio': '2',
+          },
+        }),
+      ).rejects.toThrow(/fil-ratio/)
+    })
+
+    it('rejects a non-numeric --fil-ratio', async () => {
+      process.env.OMNIPIN_PK = DUMMY_PK
+      await expect(
+        topupAction({
+          amount: '1',
+          options: {
+            provider: 'Filecoin',
+            'from-chain': 'arb',
+            'from-token': 'USDC',
+            'fil-ratio': 'half',
+          },
+        }),
+      ).rejects.toThrow(/fil-ratio/)
+    })
+
+    it('rejects a non-positive --slippage', async () => {
+      process.env.OMNIPIN_PK = DUMMY_PK
+      await expect(
+        topupAction({
+          amount: '1',
+          options: {
+            provider: 'Filecoin',
+            'from-chain': 'arb',
+            'from-token': 'USDC',
+            slippage: '0',
+          },
+        }),
+      ).rejects.toThrow(/slippage/)
+    })
+
+    it('rejects a --slippage above the cap', async () => {
+      process.env.OMNIPIN_PK = DUMMY_PK
+      await expect(
+        topupAction({
+          amount: '1',
+          options: {
+            provider: 'Filecoin',
+            'from-chain': 'arb',
+            'from-token': 'USDC',
+            slippage: '75',
+          },
+        }),
+      ).rejects.toThrow(/slippage/)
+    })
+  })
 })

--- a/test/utils/filecoin-topup.test.ts
+++ b/test/utils/filecoin-topup.test.ts
@@ -11,7 +11,7 @@ describe('filecoin-topup utils', () => {
   describe('SOURCE_CHAINS', () => {
     it('contains the seven allow-listed chains', () => {
       expect(Object.keys(SOURCE_CHAINS).sort()).toEqual(
-        ['arb', 'avalanche', 'base', 'bsc', 'eth', 'opt', 'polygon'].sort(),
+        ['arb', 'avax', 'base', 'bsc', 'eth', 'opt', 'polygon'].sort(),
       )
     })
 
@@ -22,7 +22,7 @@ describe('filecoin-topup utils', () => {
       expect(SOURCE_CHAINS.polygon.id).toBe(137)
       expect(SOURCE_CHAINS.base.id).toBe(8453)
       expect(SOURCE_CHAINS.arb.id).toBe(42161)
-      expect(SOURCE_CHAINS.avalanche.id).toBe(43114)
+      expect(SOURCE_CHAINS.avax.id).toBe(43114)
     })
   })
 

--- a/test/utils/filecoin-topup.test.ts
+++ b/test/utils/filecoin-topup.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  FILECOIN_USDFC,
+  isSourceChainKey,
+  resolveSourceToken,
+  SOURCE_CHAINS,
+} from '../../src/utils/filecoin-topup.js'
+import { NATIVE_TOKEN } from '../../src/utils/squid.js'
+
+describe('filecoin-topup utils', () => {
+  describe('SOURCE_CHAINS', () => {
+    it('contains the seven allow-listed chains', () => {
+      expect(Object.keys(SOURCE_CHAINS).sort()).toEqual(
+        ['arb', 'avalanche', 'base', 'bsc', 'eth', 'opt', 'polygon'].sort(),
+      )
+    })
+
+    it('maps each chain to its canonical chain id', () => {
+      expect(SOURCE_CHAINS.eth.id).toBe(1)
+      expect(SOURCE_CHAINS.opt.id).toBe(10)
+      expect(SOURCE_CHAINS.bsc.id).toBe(56)
+      expect(SOURCE_CHAINS.polygon.id).toBe(137)
+      expect(SOURCE_CHAINS.base.id).toBe(8453)
+      expect(SOURCE_CHAINS.arb.id).toBe(42161)
+      expect(SOURCE_CHAINS.avalanche.id).toBe(43114)
+    })
+  })
+
+  describe('FILECOIN_USDFC', () => {
+    it('is the canonical USDfc address on Filecoin', () => {
+      expect(FILECOIN_USDFC.toLowerCase()).toBe(
+        '0x80b98d3aa09ffff255c3ba4a241111ff1262f045',
+      )
+    })
+  })
+
+  describe('isSourceChainKey', () => {
+    it('accepts every allow-listed chain', () => {
+      for (const key of Object.keys(SOURCE_CHAINS)) {
+        expect(isSourceChainKey(key)).toBe(true)
+      }
+    })
+
+    it('rejects unknown chains', () => {
+      expect(isSourceChainKey('fantom')).toBe(false)
+      expect(isSourceChainKey('zksync')).toBe(false)
+      expect(isSourceChainKey('eth ')).toBe(false)
+      expect(isSourceChainKey(undefined)).toBe(false)
+    })
+  })
+
+  describe('resolveSourceToken', () => {
+    it('resolves a known symbol on the given chain', () => {
+      expect(
+        resolveSourceToken({ chain: 'arb', token: 'USDC' }).toLowerCase(),
+      ).toBe('0xaf88d065e77c8cc2239327c5edb3a432268e5831')
+    })
+
+    it('resolves case-insensitively', () => {
+      expect(
+        resolveSourceToken({ chain: 'eth', token: 'usdc' }).toLowerCase(),
+      ).toBe(SOURCE_CHAINS.eth.tokens.USDC.toLowerCase())
+    })
+
+    it('resolves a native gas token to the 0xeee sentinel', () => {
+      expect(resolveSourceToken({ chain: 'eth', token: 'ETH' })).toBe(
+        NATIVE_TOKEN,
+      )
+      expect(resolveSourceToken({ chain: 'bsc', token: 'BNB' })).toBe(
+        NATIVE_TOKEN,
+      )
+      expect(resolveSourceToken({ chain: 'polygon', token: 'POL' })).toBe(
+        NATIVE_TOKEN,
+      )
+    })
+
+    it('resolves dotted symbols like USDC.e', () => {
+      expect(
+        resolveSourceToken({ chain: 'polygon', token: 'USDC.e' }).toLowerCase(),
+      ).toBe('0x2791bca1f2de4661ed88a30c99a7a9449aa84174')
+    })
+
+    it('passes through raw 0x addresses', () => {
+      const raw = '0x1234567890123456789012345678901234567890'
+      expect(resolveSourceToken({ chain: 'eth', token: raw })).toBe(raw)
+    })
+
+    it('throws for unknown symbols', () => {
+      expect(() =>
+        resolveSourceToken({ chain: 'eth', token: 'FOOBAR' }),
+      ).toThrow(/Unknown token/)
+    })
+
+    it('rejects malformed 0x addresses (wrong length) by treating as a symbol', () => {
+      // Anything that starts with 0x but isn't 42 chars long is treated as a
+      // symbol → unknown symbol → throws.
+      expect(() =>
+        resolveSourceToken({ chain: 'eth', token: '0xabc' }),
+      ).toThrow(/Unknown token/)
+    })
+  })
+})

--- a/test/utils/squid.test.ts
+++ b/test/utils/squid.test.ts
@@ -12,10 +12,10 @@ import {
 
 const SAMPLE_PARAMS: SquidRouteParams = {
   fromAddress: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-  fromChain: 42161,
+  fromChain: "42161",
   fromToken: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
   fromAmount: '10000000',
-  toChain: 314,
+  toChain: "314",
   toToken: '0x80b98d3aa09ffff255c3ba4a241111ff1262f045',
   toAddress: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
   slippage: 1,
@@ -150,8 +150,8 @@ describe('squid utils', () => {
       ) as unknown as typeof fetch
       const res = await getStatus({
         transactionId: TX_HASH,
-        fromChainId: 42161,
-        toChainId: 314,
+        fromChainId: "42161",
+        toChainId: "314",
         fetchFn,
       })
       expect(res.squidTransactionStatus).toBe('ongoing')
@@ -163,8 +163,8 @@ describe('squid utils', () => {
       ) as unknown as typeof fetch
       const res = await getStatus({
         transactionId: TX_HASH,
-        fromChainId: 42161,
-        toChainId: 314,
+        fromChainId: "42161",
+        toChainId: "314",
         fetchFn,
       })
       expect(res.squidTransactionStatus).toBe('success')
@@ -178,8 +178,8 @@ describe('squid utils', () => {
       ) as unknown as typeof fetch
       const res = await pollSquidStatus({
         transactionId: TX_HASH,
-        fromChainId: 42161,
-        toChainId: 314,
+        fromChainId: "42161",
+        toChainId: "314",
         intervalMs: 1,
         fetchFn,
       })
@@ -192,8 +192,8 @@ describe('squid utils', () => {
       ) as unknown as typeof fetch
       const res = await pollSquidStatus({
         transactionId: TX_HASH,
-        fromChainId: 42161,
-        toChainId: 314,
+        fromChainId: "42161",
+        toChainId: "314",
         intervalMs: 1,
         fetchFn,
       })
@@ -207,8 +207,8 @@ describe('squid utils', () => {
       await expect(
         pollSquidStatus({
           transactionId: TX_HASH,
-          fromChainId: 42161,
-          toChainId: 314,
+          fromChainId: "42161",
+          toChainId: "314",
           intervalMs: 1,
           fetchFn,
         }),
@@ -222,8 +222,8 @@ describe('squid utils', () => {
       await expect(
         pollSquidStatus({
           transactionId: TX_HASH,
-          fromChainId: 42161,
-          toChainId: 314,
+          fromChainId: "42161",
+          toChainId: "314",
           intervalMs: 1,
           fetchFn,
         }),
@@ -239,8 +239,8 @@ describe('squid utils', () => {
       }) as unknown as typeof fetch
       const res = await pollSquidStatus({
         transactionId: TX_HASH,
-        fromChainId: 42161,
-        toChainId: 314,
+        fromChainId: "42161",
+        toChainId: "314",
         intervalMs: 1,
         warmupAttempts: 5,
         fetchFn,
@@ -256,8 +256,8 @@ describe('squid utils', () => {
       await expect(
         pollSquidStatus({
           transactionId: TX_HASH,
-          fromChainId: 42161,
-          toChainId: 314,
+          fromChainId: "42161",
+          toChainId: "314",
           intervalMs: 1,
           maxAttempts: 3,
           fetchFn,

--- a/test/utils/squid.test.ts
+++ b/test/utils/squid.test.ts
@@ -12,10 +12,10 @@ import {
 
 const SAMPLE_PARAMS: SquidRouteParams = {
   fromAddress: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-  fromChain: "42161",
+  fromChain: '42161',
   fromToken: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
   fromAmount: '10000000',
-  toChain: "314",
+  toChain: '314',
   toToken: '0x80b98d3aa09ffff255c3ba4a241111ff1262f045',
   toAddress: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
   slippage: 1,
@@ -150,8 +150,8 @@ describe('squid utils', () => {
       ) as unknown as typeof fetch
       const res = await getStatus({
         transactionId: TX_HASH,
-        fromChainId: "42161",
-        toChainId: "314",
+        fromChainId: '42161',
+        toChainId: '314',
         fetchFn,
       })
       expect(res.squidTransactionStatus).toBe('ongoing')
@@ -163,8 +163,8 @@ describe('squid utils', () => {
       ) as unknown as typeof fetch
       const res = await getStatus({
         transactionId: TX_HASH,
-        fromChainId: "42161",
-        toChainId: "314",
+        fromChainId: '42161',
+        toChainId: '314',
         fetchFn,
       })
       expect(res.squidTransactionStatus).toBe('success')
@@ -178,8 +178,8 @@ describe('squid utils', () => {
       ) as unknown as typeof fetch
       const res = await pollSquidStatus({
         transactionId: TX_HASH,
-        fromChainId: "42161",
-        toChainId: "314",
+        fromChainId: '42161',
+        toChainId: '314',
         intervalMs: 1,
         fetchFn,
       })
@@ -192,8 +192,8 @@ describe('squid utils', () => {
       ) as unknown as typeof fetch
       const res = await pollSquidStatus({
         transactionId: TX_HASH,
-        fromChainId: "42161",
-        toChainId: "314",
+        fromChainId: '42161',
+        toChainId: '314',
         intervalMs: 1,
         fetchFn,
       })
@@ -207,8 +207,8 @@ describe('squid utils', () => {
       await expect(
         pollSquidStatus({
           transactionId: TX_HASH,
-          fromChainId: "42161",
-          toChainId: "314",
+          fromChainId: '42161',
+          toChainId: '314',
           intervalMs: 1,
           fetchFn,
         }),
@@ -222,8 +222,8 @@ describe('squid utils', () => {
       await expect(
         pollSquidStatus({
           transactionId: TX_HASH,
-          fromChainId: "42161",
-          toChainId: "314",
+          fromChainId: '42161',
+          toChainId: '314',
           intervalMs: 1,
           fetchFn,
         }),
@@ -239,8 +239,8 @@ describe('squid utils', () => {
       }) as unknown as typeof fetch
       const res = await pollSquidStatus({
         transactionId: TX_HASH,
-        fromChainId: "42161",
-        toChainId: "314",
+        fromChainId: '42161',
+        toChainId: '314',
         intervalMs: 1,
         warmupAttempts: 5,
         fetchFn,
@@ -256,8 +256,8 @@ describe('squid utils', () => {
       await expect(
         pollSquidStatus({
           transactionId: TX_HASH,
-          fromChainId: "42161",
-          toChainId: "314",
+          fromChainId: '42161',
+          toChainId: '314',
           intervalMs: 1,
           maxAttempts: 3,
           fetchFn,

--- a/test/utils/squid.test.ts
+++ b/test/utils/squid.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import {
+  getRoute,
+  getRouteWithRetry,
+  getStatus,
+  NATIVE_TOKEN,
+  pollSquidStatus,
+  SQUID_API,
+  type SquidRouteParams,
+  squidWebUiUrl,
+} from '../../src/utils/squid.js'
+
+const SAMPLE_PARAMS: SquidRouteParams = {
+  fromAddress: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+  fromChain: 42161,
+  fromToken: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+  fromAmount: '10000000',
+  toChain: 314,
+  toToken: '0x80b98d3aa09ffff255c3ba4a241111ff1262f045',
+  toAddress: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+  slippage: 1,
+}
+
+const TX_HASH =
+  '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const
+
+const sampleRouteBody = () => ({
+  route: {
+    estimate: {
+      fromAmount: '10000000',
+      toAmount: '998000000000000000',
+      toAmountMin: '988000000000000000',
+      fromAmountUSD: '9.99',
+      toAmountUSD: '9.96',
+      estimatedRouteDuration: 150,
+      actions: [
+        {
+          type: 'swap',
+          fromToken: { symbol: 'USDC' },
+          toToken: { symbol: 'USDC.axl' },
+          provider: 'Pancakeswap V3',
+        },
+        {
+          type: 'bridge',
+          fromToken: { symbol: 'USDC.axl' },
+          toToken: { symbol: 'USDC.axl' },
+          provider: 'Axelar',
+        },
+        {
+          type: 'swap',
+          fromToken: { symbol: 'USDC.axl' },
+          toToken: { symbol: 'USDFC' },
+          provider: 'Sushiswap V3',
+        },
+      ],
+    },
+    transactionRequest: {
+      target: '0xce16F69375520ab01377ce7B88f5BA8C48F8D666',
+      data: '0xdeadbeef',
+      value: '0',
+      gasLimit: '1000000',
+    },
+    params: { requestId: 'req-abc-123' },
+  },
+})
+
+const jsonResponse = (
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  })
+
+describe('squid utils', () => {
+  const originalFetch = globalThis.fetch
+  const originalIntegrator = process.env.OMNIPIN_SQUID_INTEGRATOR_ID
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalIntegrator === undefined)
+      delete process.env.OMNIPIN_SQUID_INTEGRATOR_ID
+    else process.env.OMNIPIN_SQUID_INTEGRATOR_ID = originalIntegrator
+  })
+
+  describe('getRoute', () => {
+    it('sends the public widget integrator id by default and parses the route', async () => {
+      delete process.env.OMNIPIN_SQUID_INTEGRATOR_ID
+      let seenHeaders: Record<string, string> | undefined
+      const fetchFn = mock(
+        async (url: string | URL | Request, init?: RequestInit) => {
+          expect(String(url)).toBe(`${SQUID_API}/v2/route`)
+          seenHeaders = Object.fromEntries(new Headers(init?.headers).entries())
+          return jsonResponse(sampleRouteBody())
+        },
+      ) as unknown as typeof fetch
+
+      const route = await getRoute({ params: SAMPLE_PARAMS, fetchFn })
+      expect(route.estimate.toAmount).toBe('998000000000000000')
+      expect(route.transactionRequest.target).toBe(
+        '0xce16F69375520ab01377ce7B88f5BA8C48F8D666',
+      )
+      expect(route.params?.requestId).toBe('req-abc-123')
+      expect(seenHeaders?.['x-integrator-id']).toBe('squid-swap-widget')
+    })
+
+    it('honours OMNIPIN_SQUID_INTEGRATOR_ID override', async () => {
+      process.env.OMNIPIN_SQUID_INTEGRATOR_ID = 'my-integrator-id'
+      let seenHeaders: Record<string, string> | undefined
+      const fetchFn = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          seenHeaders = Object.fromEntries(new Headers(init?.headers).entries())
+          return jsonResponse(sampleRouteBody())
+        },
+      ) as unknown as typeof fetch
+
+      await getRoute({ params: SAMPLE_PARAMS, fetchFn })
+      expect(seenHeaders?.['x-integrator-id']).toBe('my-integrator-id')
+    })
+
+    it('throws with the web UI fallback link on non-2xx', async () => {
+      const fetchFn = mock(async () =>
+        jsonResponse(
+          { message: 'Apologies, swaps are currently unavailable.' },
+          403,
+        ),
+      ) as unknown as typeof fetch
+
+      await expect(
+        getRoute({ params: SAMPLE_PARAMS, fetchFn }),
+      ).rejects.toThrow(/Fallback: https:\/\/app\.squidrouter\.com/)
+    })
+  })
+
+  describe('squidWebUiUrl', () => {
+    it('encodes from/to chains and tokens', () => {
+      const url = squidWebUiUrl(SAMPLE_PARAMS)
+      expect(url).toContain('chains=42161%2C314')
+      expect(url).toContain(SAMPLE_PARAMS.fromToken)
+      expect(url).toContain(SAMPLE_PARAMS.toToken)
+    })
+  })
+
+  describe('getStatus', () => {
+    it('treats 404 as ongoing', async () => {
+      const fetchFn = mock(
+        async () => new Response('', { status: 404 }),
+      ) as unknown as typeof fetch
+      const res = await getStatus({
+        transactionId: TX_HASH,
+        fromChainId: 42161,
+        toChainId: 314,
+        fetchFn,
+      })
+      expect(res.squidTransactionStatus).toBe('ongoing')
+    })
+
+    it('returns the status body on 200', async () => {
+      const fetchFn = mock(async () =>
+        jsonResponse({ squidTransactionStatus: 'success' }),
+      ) as unknown as typeof fetch
+      const res = await getStatus({
+        transactionId: TX_HASH,
+        fromChainId: 42161,
+        toChainId: 314,
+        fetchFn,
+      })
+      expect(res.squidTransactionStatus).toBe('success')
+    })
+  })
+
+  describe('pollSquidStatus', () => {
+    it('resolves on success', async () => {
+      const fetchFn = mock(async () =>
+        jsonResponse({ squidTransactionStatus: 'success' }),
+      ) as unknown as typeof fetch
+      const res = await pollSquidStatus({
+        transactionId: TX_HASH,
+        fromChainId: 42161,
+        toChainId: 314,
+        intervalMs: 1,
+        fetchFn,
+      })
+      expect(res.squidTransactionStatus).toBe('success')
+    })
+
+    it('resolves on partial_success', async () => {
+      const fetchFn = mock(async () =>
+        jsonResponse({ squidTransactionStatus: 'partial_success' }),
+      ) as unknown as typeof fetch
+      const res = await pollSquidStatus({
+        transactionId: TX_HASH,
+        fromChainId: 42161,
+        toChainId: 314,
+        intervalMs: 1,
+        fetchFn,
+      })
+      expect(res.squidTransactionStatus).toBe('partial_success')
+    })
+
+    it('throws on refund', async () => {
+      const fetchFn = mock(async () =>
+        jsonResponse({ squidTransactionStatus: 'refund' }),
+      ) as unknown as typeof fetch
+      await expect(
+        pollSquidStatus({
+          transactionId: TX_HASH,
+          fromChainId: 42161,
+          toChainId: 314,
+          intervalMs: 1,
+          fetchFn,
+        }),
+      ).rejects.toThrow(/refund/)
+    })
+
+    it('throws on needs_gas', async () => {
+      const fetchFn = mock(async () =>
+        jsonResponse({ squidTransactionStatus: 'needs_gas' }),
+      ) as unknown as typeof fetch
+      await expect(
+        pollSquidStatus({
+          transactionId: TX_HASH,
+          fromChainId: 42161,
+          toChainId: 314,
+          intervalMs: 1,
+          fetchFn,
+        }),
+      ).rejects.toThrow(/needs_gas/)
+    })
+
+    it('tolerates warmup 404s and eventually resolves', async () => {
+      let n = 0
+      const fetchFn = mock(async () => {
+        n += 1
+        if (n < 3) return new Response('', { status: 404 })
+        return jsonResponse({ squidTransactionStatus: 'success' })
+      }) as unknown as typeof fetch
+      const res = await pollSquidStatus({
+        transactionId: TX_HASH,
+        fromChainId: 42161,
+        toChainId: 314,
+        intervalMs: 1,
+        warmupAttempts: 5,
+        fetchFn,
+      })
+      expect(res.squidTransactionStatus).toBe('success')
+      expect(n).toBe(3)
+    })
+
+    it('times out if status never reaches terminal', async () => {
+      const fetchFn = mock(async () =>
+        jsonResponse({ squidTransactionStatus: 'ongoing' }),
+      ) as unknown as typeof fetch
+      await expect(
+        pollSquidStatus({
+          transactionId: TX_HASH,
+          fromChainId: 42161,
+          toChainId: 314,
+          intervalMs: 1,
+          maxAttempts: 3,
+          fetchFn,
+        }),
+      ).rejects.toThrow(/timed out/)
+    })
+  })
+
+  describe('getRouteWithRetry', () => {
+    it('retries on "Too many quote requests" then resolves', async () => {
+      let n = 0
+      const fetchFn = mock(async () => {
+        n += 1
+        if (n === 1) {
+          return jsonResponse(
+            { error: 'Too many quote requests for this address' },
+            429,
+          )
+        }
+        return jsonResponse(sampleRouteBody())
+      }) as unknown as typeof fetch
+
+      const route = await getRouteWithRetry({
+        params: SAMPLE_PARAMS,
+        attempts: 3,
+        initialDelayMs: 1,
+        fetchFn,
+      })
+      expect(route.estimate.toAmountUSD).toBe('9.96')
+      expect(n).toBe(2)
+    })
+
+    it('surfaces non-rate-limit errors immediately without retry', async () => {
+      const fetchFn = mock(async () =>
+        jsonResponse(
+          { message: 'Apologies, swaps are currently unavailable.' },
+          403,
+        ),
+      ) as unknown as typeof fetch
+
+      await expect(
+        getRouteWithRetry({
+          params: SAMPLE_PARAMS,
+          attempts: 3,
+          initialDelayMs: 1,
+          fetchFn,
+        }),
+      ).rejects.toThrow(/Squid quote failed/)
+      // Should only be called once (no retry on non-429 errors).
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('NATIVE_TOKEN', () => {
+    it('is the canonical 0xeee… sentinel', () => {
+      expect(NATIVE_TOKEN).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
+    })
+  })
+})


### PR DESCRIPTION
Stacked on top of #154 (AIOZ topup). Will retarget to `main` once #154 merges.

## Summary

Adds a Filecoin branch to `omnipin topup` that delivers both **native FIL** (gas) and **USDfc** (storage payment) to a Filecoin address in a single invocation, via [Squid Router](https://app.squidrouter.com).

## Usage

```sh
OMNIPIN_PK=0x... omnipin topup --provider=Filecoin \
  --from-chain=arb --from-token=USDC 10 --to=<filecoin_address>
```

Source chains: `eth`, `opt`, `bsc`, `polygon`, `base`, `arb`, `avalanche`.
`--from-token` accepts known symbols (USDC, USDT, ETH, BNB, MATIC, AVAX, WETH, USDC.e, …) or a raw `0x` address.

## Mechanics

For each invocation, the orchestrator:

1. Requests two Squid `/v2/route` quotes: `amount × fil-ratio` → native FIL and `amount × (1 − fil-ratio)` → USDfc. Both surface route errors before any on-chain action.
2. For ERC-20 inputs, approves the Squid router once for the cumulative amount.
3. Executes the FIL leg, waits for the source tx, polls `/v2/status` until `success` / `partial_success` (terminal failures `refund` / `needs_gas` throw with an axelarscan deeplink).
4. Same for the USDfc leg.

## Why Squid

Permissionless alternatives that bridge to Filecoin (chain 314):

| Bridge | Filecoin? | API key? | Delivers FIL+USDfc? |
|---|---|---|---|
| **Squid** | ✅ | None (public widget integrator ID) | ✅ |
| LI.FI | ❌ Filecoin not in chain list | n/a | n/a |
| deBridge DLN | ❌ Filecoin not in supported chains | n/a | n/a |
| Across | partial | Bearer key required | n/a |
| Stargate | ❌ no Filecoin pool | n/a | n/a |
| Celer cBridge | defunct | n/a | n/a |
| Axelar Gateway direct | ✅ but lands `axlUSDC` / `WFIL` only | None (on-chain) | ❌ destination-side gas chicken-and-egg |

Axelar Gateway alone delivers `axlUSDC` or `WFIL` on Filecoin, but the recipient needs FIL gas to swap or unwrap. Squid solves this by bundling everything into one source-chain tx whose pre-paid Axelar gas service deposit covers destination execution. Reimplementing this ourselves means deploying a Filecoin contract that mirrors Squid's `0xce16…D666` router — out of scope.

The Squid integrator ID is the public `squid-swap-widget` identity that the official Squid front-end at v2.app.squidrouter.com uses on every request. Overridable via `OMNIPIN_SQUID_INTEGRATOR_ID`.

## Files

- `src/utils/squid.ts` — `getRoute`, `getStatus`, `pollSquidStatus`, `getRouteWithRetry`, web-UI deeplink builder.
- `src/utils/filecoin-topup.ts` — orchestrator + per-chain symbol→address table + ERC-20 allowance management.
- `src/actions/topup.ts` — dispatches `Filecoin` provider alongside `AIOZ`.
- `src/cli.ts` — `--from-token`, `--fil-ratio`, `--slippage` options.
- `docs/cli/topup.md` — Filecoin section.
- 26 new tests (mocked fetch) covering route fetching, status polling, retry on rate-limit, source-chain allow-list, token resolution, arg validation.

## Test results

```
bun test test/utils/squid.test.ts test/utils/filecoin-topup.test.ts test/actions/topup.test.ts
42 pass, 0 fail
```

## Out of scope

- Axelar Gateway fallback path (would still need destination-side FIL gas).
- Filecoin calibration testnet (no Squid liquidity there).
- Withdraw direction (Filecoin → ETH/L2).