### PR TITLE
feat: split topup into bridge and deposit commands

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -301,6 +301,14 @@ export default withMermaid({
             text: 'Zodiac',
             link: '/cli/zodiac',
           },
+          {
+            text: 'Bridge',
+            link: '/cli/bridge',
+          },
+          {
+            text: 'Deposit',
+            link: '/cli/deposit',
+          },
         ],
       },
     ],

--- a/docs/cli/bridge.md
+++ b/docs/cli/bridge.md
@@ -1,14 +1,17 @@
-# `omnipin topup`
+# `omnipin bridge`
 
-Bridge and deposit native tokens to a provider account. Supports **AIOZ**
-and **Filecoin**.
+Bridge native tokens from a source chain into a provider's chain. Supports
+**AIOZ** (chain 168) and **Filecoin** (chain 314). `bridge` stops once the
+bridged funds land in the destination wallet — for Filecoin you typically
+follow up with [`omnipin deposit`](./deposit) to move the bridged USDfc into
+Filecoin Pay.
 
 ```sh
 # AIOZ: bridge native AIOZ from Ethereum or BSC into an AIOZ Network address.
-OMNIPIN_PK=0x... omnipin topup --provider=AIOZ --from-chain=eth <amount> --to=<address>
+OMNIPIN_PK=0x... omnipin bridge --provider=AIOZ --from-chain=eth <amount> --to=<address>
 
 # Filecoin: swap any supported source token into FIL (gas) + USDfc (storage).
-OMNIPIN_PK=0x... omnipin topup --provider=Filecoin \
+OMNIPIN_PK=0x... omnipin bridge --provider=Filecoin \
   --from-chain=arb --from-token=USDC <amount> --to=<filecoin_address>
 ```
 
@@ -22,7 +25,7 @@ token's on-chain `decimals()` (e.g. `10` with `--from-token=USDC` means
 ## How it works (AIOZ)
 
 The AIOZ bridge is a deposit-address / hot-wallet design — there is no
-contract on the deposit side, no approval, no event ABI. The full top-up
+contract on the deposit side, no approval, no event ABI. The full bridge
 runs in three steps:
 
 1. Look up the live pool address for the chosen direction from the AIOZ
@@ -42,7 +45,7 @@ mainnet for the optional forward step.
 
 ### `provider`
 
-Provider to top up. One of `AIOZ` or `Filecoin`.
+Provider to bridge for. One of `AIOZ` or `Filecoin`.
 
 ### `from-chain`
 
@@ -91,13 +94,12 @@ More verbose logs, including per-poll status updates from the relayer.
 
 ## How it works (Filecoin)
 
-Filecoin top-ups go through [Squid Router](https://app.squidrouter.com),
+Filecoin bridging goes through [Squid Router](https://app.squidrouter.com),
 which wraps Axelar's cross-chain bridge with destination-side gas payment
 and an on-chain DEX swap on Filecoin (Sushiswap V3 against the
 `axlUSDC` / `USDfc` / `WFIL` pools). This means a single source-chain
 transaction can deliver native FIL **and** USDfc on Filecoin without the
-recipient needing FIL for destination gas. The bridged USDfc is then
-automatically deposited into **Filecoin Pay** for storage payments.
+recipient needing FIL for destination gas.
 
 For each invocation:
 
@@ -109,11 +111,14 @@ For each invocation:
 3. The FIL leg is executed and polled on Squid's `/v2/status` until
    `success`.
 4. The USDfc leg is executed and polled the same way.
-5. After the USDfc balance arrives on Filecoin, it is deposited into
-   **Filecoin Pay** via `depositWithPermit` (or
-   `depositWithPermitAndApproveOperator` for first-time deposits). This
-   credits the storage payment contract so the `Filecoin` IPFS provider
-   can use the funds for dataset uploads.
+
+After `bridge` returns, the bridged USDfc sits in the destination wallet
+on Filecoin. To make it spendable by the `Filecoin` IPFS provider, run
+[`omnipin deposit`](./deposit) to move it into Filecoin Pay:
+
+```sh
+OMNIPIN_PK=0x... omnipin deposit --provider=Filecoin <usdfc-amount>
+```
 
 If Squid's API returns a non-2xx, the error includes a deeplink to the
 Squid web UI (`https://app.squidrouter.com/?chains=…&tokens=…`) preserving
@@ -133,7 +138,7 @@ own integrator ID:
 export OMNIPIN_SQUID_INTEGRATOR_ID=your-integrator-id
 ```
 
-This is useful when running many top-ups from the same address (Squid
+This is useful when running many bridges from the same address (Squid
 rate-limits quote requests per `fromAddress`).
 
 ## Environment
@@ -163,9 +168,5 @@ rate-limits quote requests per `fromAddress`).
   errors during heavy use. Omnipin retries with exponential backoff.
 - USDfc is the canonical USD-pegged storage payment token used by the
   `Filecoin` IPFS provider (see [docs/docs/filecoin.md](../docs/filecoin)).
-- After bridging, USDfc is deposited into Filecoin Pay via
-  `depositWithPermit` (EIP-2612 permit, no prior ERC-20 approval needed).
-  First-time deposits also set max operator approval for the FWSS
-  storage contract in the same transaction.
 - Filecoin EVM chain ID is `314` (hex `0x13a`). Default RPC:
   `https://api.node.glif.io/rpc/v1`. Explorer: `https://filfox.info`.

--- a/docs/cli/deposit.md
+++ b/docs/cli/deposit.md
@@ -1,0 +1,78 @@
+# `omnipin deposit`
+
+Deposit already-held tokens into a provider's payment contract. Today this
+is **Filecoin-only** — it moves USDfc from the signer's Filecoin wallet
+into [Filecoin Pay](https://docs.filecoin.io) (the storage payment
+contract used by the `Filecoin` IPFS provider).
+
+Use `deposit` when:
+
+- You bought USDfc directly on Filecoin (via SushiSwap, a faucet on
+  calibnet, an OTC transfer, etc.) and want to skip the bridge.
+- You have leftover USDfc in your wallet from a previous bridge and want
+  to top up your storage allowance without bridging again.
+
+To bridge from another chain first, use [`omnipin bridge`](./bridge) and
+then call `deposit` to move the bridged USDfc into Filecoin Pay.
+
+```sh
+OMNIPIN_PK=0x... omnipin deposit --provider=Filecoin <amount>
+```
+
+`<amount>` is in whole USDfc tokens (18 decimals), e.g. `5` deposits
+5 USDfc.
+
+## How it works
+
+1. The wallet's USDfc balance on Filecoin (chain 314) is checked. If it
+   is below `<amount>` the command aborts with a friendly error — no tx
+   is sent.
+2. Omnipin checks whether the wallet has already granted max approval to
+   the FWSS (filecoin-warm-storage-service) operator contract:
+   - If yes, it calls `FilecoinPayV1.depositWithPermit` (single tx, signs
+     an EIP-2612 permit so no separate ERC-20 approval is needed).
+   - If no, it calls `FilecoinPayV1.depositWithPermitAndApproveOperator`
+     instead, which deposits **and** sets max operator approval in the
+     same tx. This is the typical path for first-time deposits.
+3. The deposit transaction is broadcast on Filecoin EVM and the command
+   waits for confirmation.
+
+After this, the deposited USDfc is credited inside Filecoin Pay and the
+`Filecoin` IPFS provider can spend it to pay storage providers during
+`omnipin deploy`.
+
+## Options
+
+### `provider`
+
+Provider to deposit for. Currently only `Filecoin` is supported. AIOZ
+does not have a separate deposit step — `bridge` is the whole flow there.
+
+### `from`
+
+Wallet address holding the USDfc on Filecoin. Defaults to the signer's
+own address (derived from `OMNIPIN_PK`). Use this when the funds are held
+by an address different from the signer (rare — the signer must still
+hold the private key used to sign the EIP-2612 permit, so this is mostly
+useful for testing).
+
+### `verbose`
+
+More verbose logs.
+
+## Environment
+
+- `OMNIPIN_PK` — private key (hex, `0x`-prefixed) used to sign the
+  EIP-2612 permit and broadcast the deposit transaction.
+
+## Notes
+
+- Filecoin EVM chain ID is `314` (hex `0x13a`). Default RPC:
+  `https://api.node.glif.io/rpc/v1`. Explorer: `https://filfox.info`.
+- USDfc on Filecoin: `0x80b98d3aa09ffff255c3ba4a241111ff1262f045`.
+- The deposit goes into Filecoin Pay, which is the same payment rail used
+  by the official Synapse SDK; balances deposited here are visible to
+  any tool that reads from Filecoin Pay.
+- First-time deposits cost slightly more gas because they also set
+  operator approval. Subsequent deposits use the cheaper
+  `depositWithPermit` path automatically.

--- a/docs/docs/ipfs.md
+++ b/docs/docs/ipfs.md
@@ -147,13 +147,28 @@ OMNIPIN_FILECOIN_TOKEN=0xdeadbeef
 
 Top up the wallet with a bit of FIL and USDfc.
 
-Buy FIL and USDfc via
+The easiest path is the built-in `bridge` command, which routes a source
+token (e.g. USDC on Arbitrum) into both FIL (gas) and USDfc (storage payment)
+on Filecoin via [Squid Router](https://app.squidrouter.com):
+
+```sh
+omnipin bridge --provider=Filecoin \
+  --from-chain=arb --from-token=USDC 10
+omnipin deposit --provider=Filecoin 9
+```
+
+`bridge` lands the funds in your Filecoin wallet; `deposit` then moves the
+USDfc into Filecoin Pay so the storage provider can spend it. See
+[`omnipin bridge`](../cli/bridge) and [`omnipin deposit`](../cli/deposit) for
+details.
+
+Alternatively, buy FIL and USDfc manually via
 [Squid Router](https://app.squidrouter.com/?chains=137%2C314&tokens=0x3c499c542cef5e3811e1192ce70d8cc03d5c3359%2C0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee)
 or
 [SushiSwap](https://www.sushi.com/filecoin/swap?token0=NATIVE&token1=0x80b98d3aa09ffff255c3ba4a241111ff1262f045).
-It is recommended to bridge a bit of FIL first, and then swap a portion of it to
-USDfc, since cross-chain swaps for USDfc have low liquidity in pools. For most
-(<10GB) uploads, $1 of USDfc and 0.1 FIL should be enough.
+For most (<10GB) uploads, $1 of USDfc and 0.1 FIL should be enough. If you
+buy USDfc manually, you can still call `omnipin deposit --provider=Filecoin`
+to move it into Filecoin Pay.
 
 If using the calibration testnet, you can get USDfc through a faucet as well
 [here](https://forest-explorer.chainsafe.dev/faucet/calibnet_usdfc).
@@ -301,18 +316,18 @@ OMNIPIN_AIOZ_TOKEN=your_api_key:your_api_secret
 ### Top-up
 
 AIOZ requires a balance on AIOZ Network (chain 168) to pin content. Use the
-`topup` command to bridge AIOZ tokens from a source chain:
+`bridge` command to bridge AIOZ tokens from a source chain:
 
 ```sh
-omnipin topup --provider=AIOZ \
+omnipin bridge --provider=AIOZ \
   --from-chain=eth \
   --to=0xYOUR_AIOZ_PIN_ACCOUNT \
   0.5
 ```
 
-Supported source chains: `eth`, `arb`, `opt`, `bsc`, `base`, `polygon`,
-`avalanche`. The command bridges AIOZ from the source chain to AIOZ Network,
-then forwards the funds to your AIOZ-Pin account.
+Supported source chains: `eth`, `bsc`. The command bridges AIOZ from the
+source chain to AIOZ Network, then forwards the funds to your AIOZ-Pin
+account. See [`omnipin bridge`](../cli/bridge) for details.
 
 ## Blockfrost
 

--- a/src/actions/bridge.ts
+++ b/src/actions/bridge.ts
@@ -9,15 +9,15 @@ import {
 import {
   SOURCE_CHAINS as AIOZ_SOURCE_CHAINS,
   type SourceChain as AiozSourceChain,
-  topupAioz,
+  bridgeAioz,
 } from '../utils/aioz-bridge.js'
 import {
+  bridgeFilecoin,
   isSourceChainKey as isFilecoinSourceChainKey,
-  topupFilecoin,
-} from '../utils/filecoin-topup.js'
+} from '../utils/filecoin-bridge.js'
 import { logger } from '../utils/logger.js'
 
-export type TopupActionArgs = Partial<{
+export type BridgeActionArgs = Partial<{
   provider: string
   'from-chain': string
   'from-token': string
@@ -34,12 +34,12 @@ const SUPPORTED_PROVIDERS = new Set(['AIOZ', 'Filecoin'])
 const isAiozSourceChain = (v: string | undefined): v is AiozSourceChain =>
   typeof v === 'string' && v in AIOZ_SOURCE_CHAINS
 
-export const topupAction = async ({
+export const bridgeAction = async ({
   amount,
   options = {},
 }: {
   amount: string
-  options: TopupActionArgs
+  options: BridgeActionArgs
 }) => {
   if (!amount) throw new MissingCLIArgsError(['amount'])
 
@@ -64,9 +64,9 @@ export const topupAction = async ({
     }
     if (amountWei <= 0n) throw new Error(`Amount must be positive: ${amount}`)
 
-    logger.start(`Top-up ${amount} AIOZ via ${provider} bridge`)
+    logger.start(`Bridge ${amount} AIOZ via ${provider} bridge`)
 
-    const result = await topupAioz({
+    const result = await bridgeAioz({
       privateKey: pk,
       fromChain,
       amountWei,
@@ -76,7 +76,7 @@ export const topupAction = async ({
       aiozRpcUrl: options['aioz-rpc-url'],
     })
 
-    logger.success('Top-up complete')
+    logger.success('Bridge complete')
     if (options.verbose) {
       logger.text(JSON.stringify(result, null, 2))
     }
@@ -109,7 +109,7 @@ export const topupAction = async ({
       )
     }
 
-    const result = await topupFilecoin({
+    const result = await bridgeFilecoin({
       privateKey: pk,
       fromChain,
       fromToken,

--- a/src/actions/deposit.ts
+++ b/src/actions/deposit.ts
@@ -1,0 +1,56 @@
+import type { Address } from 'ox/Address'
+import type { Hex } from 'ox/Hex'
+import {
+  MissingCLIArgsError,
+  MissingKeyError,
+  UnknownProviderError,
+} from '../errors.js'
+import { depositFilecoinUsdfc } from '../utils/filecoin-deposit.js'
+import { logger } from '../utils/logger.js'
+
+export type DepositActionArgs = Partial<{
+  provider: string
+  from: Address
+  verbose: boolean
+}>
+
+/**
+ * Providers that have a separate deposit step on top of holding the
+ * underlying token. Today only Filecoin has one (Filecoin Pay). AIOZ stores
+ * the bill in native AIOZ on the AIOZ Network itself, so `bridge` is the
+ * whole flow there.
+ */
+const SUPPORTED_PROVIDERS = new Set(['Filecoin'])
+
+export const depositAction = async ({
+  amount,
+  options = {},
+}: {
+  amount: string
+  options: DepositActionArgs
+}) => {
+  if (!amount) throw new MissingCLIArgsError(['amount'])
+
+  const provider = options.provider
+  if (!provider) throw new MissingCLIArgsError(['provider'])
+  if (!SUPPORTED_PROVIDERS.has(provider))
+    throw new UnknownProviderError(provider)
+
+  const pk = process.env.OMNIPIN_PK as Hex | undefined
+  if (!pk) throw new MissingKeyError('PK')
+
+  if (provider === 'Filecoin') {
+    logger.start(`Deposit ${amount} USDfc to Filecoin Pay`)
+
+    const result = await depositFilecoinUsdfc({
+      privateKey: pk,
+      amount,
+      from: options.from,
+      verbose: options.verbose,
+    })
+
+    if (options.verbose) {
+      logger.text(JSON.stringify(result, null, 2))
+    }
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,14 +3,15 @@
 import type { Address } from 'ox/Address'
 import { CLI } from 'spektr'
 import { colorPlugin } from 'spektr/plugins/color.js'
+import { type BridgeActionArgs, bridgeAction } from './actions/bridge.js'
 import { type DeployActionArgs, deployAction } from './actions/deploy.js'
+import { type DepositActionArgs, depositAction } from './actions/deposit.js'
 import { dnsLinkAction } from './actions/dnslink.js'
 import { type EnsActionArgs, ensAction } from './actions/ens.js'
 import { packAction } from './actions/pack.js'
 import { pinAction } from './actions/pin.js'
 import { pingAction } from './actions/ping.js'
 import { statusAction } from './actions/status.js'
-import { type TopupActionArgs, topupAction } from './actions/topup.js'
 import { zodiacAction } from './actions/zodiac.js'
 import { isTTY } from './constants.js'
 
@@ -267,18 +268,19 @@ cli.command<[string]>('pin', ([cid], options) => pinAction({ cid, options }), {
 })
 
 cli.command<[string]>(
-  'topup',
+  'bridge',
   ([amount], options) =>
-    topupAction({
+    bridgeAction({
       amount: amount as string,
-      options: options as TopupActionArgs,
+      options: options as BridgeActionArgs,
     }),
   {
-    description: 'Bridge and top up native tokens for a provider',
+    description:
+      'Bridge native tokens to a provider chain. Stops once the funds land in the destination wallet.',
     options: [
       {
         name: 'provider',
-        description: 'Provider to top up (AIOZ or Filecoin)',
+        description: 'Provider to bridge to (AIOZ or Filecoin)',
         type: 'string',
       },
       {
@@ -319,6 +321,38 @@ cli.command<[string]>(
         name: 'slippage',
         description:
           'Maximum acceptable slippage in percent for Squid swaps. Filecoin only. Default 1.',
+        type: 'string',
+      },
+      {
+        name: 'verbose',
+        description: 'More verbose logs',
+        type: 'boolean',
+        short: 'v',
+      },
+    ] as const,
+  },
+)
+
+cli.command<[string]>(
+  'deposit',
+  ([amount], options) =>
+    depositAction({
+      amount: amount as string,
+      options: options as DepositActionArgs,
+    }),
+  {
+    description:
+      'Deposit already-held tokens into a provider payment contract (Filecoin: USDfc → Filecoin Pay).',
+    options: [
+      {
+        name: 'provider',
+        description: 'Provider to deposit for (Filecoin)',
+        type: 'string',
+      },
+      {
+        name: 'from',
+        description:
+          'Wallet address holding the tokens. Defaults to the signer address.',
         type: 'string',
       },
       {

--- a/src/utils/aioz-bridge.ts
+++ b/src/utils/aioz-bridge.ts
@@ -182,10 +182,10 @@ export const pollSwapStatus = async ({
 }
 
 /**
- * Full top-up flow: bridge AIOZ from ETH/BSC to AIOZ mainnet, then optionally
- * forward the native AIOZ to a destination address.
+ * Bridge AIOZ from ETH/BSC to AIOZ mainnet, then optionally forward the
+ * native AIOZ to a destination address.
  */
-export const topupAioz = async ({
+export const bridgeAioz = async ({
   privateKey,
   fromChain,
   amountWei,

--- a/src/utils/filecoin-bridge.ts
+++ b/src/utils/filecoin-bridge.ts
@@ -1,10 +1,3 @@
-import {
-  depositWithPermitAndApproveOperatorWriteParameters,
-  depositWithPermitWriteParameters,
-  getUSDfcBalance,
-  isFwssMaxApproved,
-} from '@omnipin/foc/fil-pay'
-import { filecoinMainnet, filProvider } from '@omnipin/foc/utils'
 import { encodeData } from 'ox/AbiFunction'
 import { type Address, fromPublicKey } from 'ox/Address'
 import { type Hex, toBigInt } from 'ox/Hex'
@@ -12,7 +5,6 @@ import * as Provider from 'ox/Provider'
 import { fromHttp } from 'ox/RpcTransport'
 import { getPublicKey } from 'ox/Secp256k1'
 import * as Value from 'ox/Value'
-import { setTimeout } from '../deps.js'
 import { logger } from './logger.js'
 import {
   getRouteWithRetry,
@@ -274,7 +266,7 @@ const ensureAllowance = async ({
   await waitForTransaction(provider, txHash)
 }
 
-export type FilecoinTopupResult = {
+export type FilecoinBridgeResult = {
   /** Source-chain transaction that triggered the USDfc bridge leg. */
   usdfcTxHash?: Hex
   /** Source-chain transaction that triggered the FIL bridge leg. */
@@ -285,10 +277,14 @@ export type FilecoinTopupResult = {
 }
 
 /**
- * Top up Filecoin: bridge a portion of the input token to native FIL (gas)
- * and the rest to USDfc (storage payment) via Squid Router.
+ * Bridge a portion of the input token to native FIL (gas) and the rest to
+ * USDfc (storage payment) on Filecoin via Squid Router.
+ *
+ * This stops once the funds land in the destination wallet. To deposit the
+ * bridged USDfc into Filecoin Pay (so the `Filecoin` IPFS provider can spend
+ * it on storage), call `depositFilecoinUsdfc` afterwards.
  */
-export const topupFilecoin = async ({
+export const bridgeFilecoin = async ({
   privateKey,
   fromChain,
   fromToken,
@@ -310,7 +306,7 @@ export const topupFilecoin = async ({
   slippage: number
   sourceRpcUrl?: string
   verbose?: boolean
-}): Promise<FilecoinTopupResult> => {
+}): Promise<FilecoinBridgeResult> => {
   if (filRatio < 0 || filRatio > 1) {
     throw new Error(`--fil-ratio must be in [0, 1], got ${filRatio}`)
   }
@@ -341,7 +337,7 @@ export const topupFilecoin = async ({
   const usdfcAtomic = totalAmountAtomic - filAtomic
 
   logger.start(
-    `Top-up Filecoin: ${amount} ${fromToken} from ${chainConfig.name} → ${destination}`,
+    `Bridge to Filecoin: ${amount} ${fromToken} from ${chainConfig.name} → ${destination}`,
   )
   logger.info(
     `Split: ${filAtomic} (FIL leg) + ${usdfcAtomic} (USDfc leg), source-token atomic units`,
@@ -405,7 +401,7 @@ export const topupFilecoin = async ({
     })
   }
 
-  const result: FilecoinTopupResult = {}
+  const result: FilecoinBridgeResult = {}
 
   if (filRoute && filParams) {
     logger.info(`Executing FIL leg on ${chainConfig.name}`)
@@ -459,51 +455,7 @@ export const topupFilecoin = async ({
     result.usdfcStatus = status
   }
 
-  // Deposit bridged USDfc to Filecoin Pay
-  if (usdfcAtomic > 0n) {
-    logger.info('Waiting for USDfc balance to arrive on Filecoin…')
-    const usdfcBalance = await waitForUsdfcBalance({
-      address: destination,
-      minimumWei: usdfcAtomic,
-      verbose,
-    })
-
-    logger.info(
-      `Depositing ${Value.format(usdfcBalance, 18)} USDfc to Filecoin Pay`,
-    )
-
-    const alreadyApproved = await isFwssMaxApproved({
-      clientAddress: destination,
-      chain: filecoinMainnet,
-    })
-
-    const params = alreadyApproved
-      ? await depositWithPermitWriteParameters({
-          privateKey,
-          address: destination,
-          amount: usdfcBalance,
-          chain: filecoinMainnet,
-        })
-      : await depositWithPermitAndApproveOperatorWriteParameters({
-          privateKey,
-          address: destination,
-          amount: usdfcBalance,
-          chain: filecoinMainnet,
-        })
-
-    const depositHash = (await sendTransaction({
-      ...params,
-      chainId: filecoinMainnet.id,
-      privateKey,
-    })) as Hex
-
-    logger.info(`Deposit tx: ${FILECOIN_MAINNET.explorer}/tx/${depositHash}`)
-
-    await waitForTransaction(filProvider[filecoinMainnet.id], depositHash)
-    logger.success('Deposit confirmed')
-  }
-
-  logger.success('Filecoin top-up complete')
+  logger.success('Filecoin bridge complete')
   return result
 }
 
@@ -543,42 +495,5 @@ const logRouteSummary = (label: string, route: SquidRoute) => {
     .join(' / ')
   logger.info(
     `  ${label}: $${est.fromAmountUSD} → $${est.toAmountUSD} (${est.estimatedRouteDuration}s) [${actions}]`,
-  )
-}
-
-/**
- * Poll Filecoin RPC until the address's USDfc balance reaches at least
- * `minimumWei`. The Squid relayer reports `success` as soon as the
- * destination tx is mined, but some RPC providers lag by a few seconds
- * before exposing the new balance.
- */
-const waitForUsdfcBalance = async ({
-  address,
-  minimumWei,
-  maxAttempts = 60,
-  intervalMs = 10_000,
-  verbose,
-}: {
-  address: Address
-  minimumWei: bigint
-  maxAttempts?: number
-  intervalMs?: number
-  verbose?: boolean
-}): Promise<bigint> => {
-  for (let i = 0; i < maxAttempts; i++) {
-    const balance = await getUSDfcBalance({
-      address,
-      chain: filecoinMainnet,
-    })
-    if (balance >= minimumWei) return balance
-    if (verbose && i % 5 === 0) {
-      logger.info(
-        `Waiting for USDfc balance (have ${Value.format(balance, 18)}, need ${Value.format(minimumWei, 18)})`,
-      )
-    }
-    await setTimeout(intervalMs)
-  }
-  throw new Error(
-    `USDfc balance did not reach ${Value.format(minimumWei, 18)} within ${maxAttempts} polls`,
   )
 }

--- a/src/utils/filecoin-deposit.ts
+++ b/src/utils/filecoin-deposit.ts
@@ -1,0 +1,158 @@
+import {
+  depositWithPermitAndApproveOperatorWriteParameters,
+  depositWithPermitWriteParameters,
+  getUSDfcBalance,
+  isFwssMaxApproved,
+} from '@omnipin/foc/fil-pay'
+import { filecoinMainnet, filProvider } from '@omnipin/foc/utils'
+import { type Address, fromPublicKey } from 'ox/Address'
+import type { Hex } from 'ox/Hex'
+import { getPublicKey } from 'ox/Secp256k1'
+import * as Value from 'ox/Value'
+import { setTimeout } from '../deps.js'
+import { FILECOIN_MAINNET } from './filecoin-bridge.js'
+import { logger } from './logger.js'
+import { sendTransaction, waitForTransaction } from './tx.js'
+
+export type FilecoinDepositResult = {
+  /** Filecoin tx hash of the depositWithPermit / …AndApproveOperator call. */
+  depositTxHash: Hex
+  /** Amount actually deposited, in USDfc atomic units (18 decimals). */
+  depositedAmount: bigint
+}
+
+/**
+ * Deposit existing USDfc on Filecoin into Filecoin Pay (the storage payment
+ * contract). Used both as the second leg of a full bridge+deposit top-up and
+ * as a standalone command for users who already hold USDfc on Filecoin.
+ *
+ * @param amount Whole USDfc to deposit (e.g. `'5'` ⇒ 5 USDfc). 18 decimals.
+ * @param waitForBalance When true, poll Filecoin until the wallet's USDfc
+ *   balance reaches `amount`. Set by the bridge flow because Squid's relayer
+ *   reports `success` slightly before the destination RPC exposes the new
+ *   balance. Default: `false` (assume the balance is already there).
+ */
+export const depositFilecoinUsdfc = async ({
+  privateKey,
+  amount,
+  from,
+  waitForBalance = false,
+  verbose,
+}: {
+  privateKey: Hex
+  amount: string
+  /** Wallet address holding the USDfc. Defaults to the signer's address. */
+  from?: Address
+  waitForBalance?: boolean
+  verbose?: boolean
+}): Promise<FilecoinDepositResult> => {
+  const signer = fromPublicKey(getPublicKey({ privateKey }))
+  const owner = (from ?? signer) as Address
+
+  let amountAtomic: bigint
+  try {
+    amountAtomic = Value.from(amount, 18)
+  } catch {
+    throw new Error(`Invalid amount: ${amount}`)
+  }
+  if (amountAtomic <= 0n) {
+    throw new Error(`Amount must be positive: ${amount}`)
+  }
+
+  if (waitForBalance) {
+    logger.info('Waiting for USDfc balance to arrive on Filecoin…')
+    await waitForUsdfcBalance({
+      address: owner,
+      minimumAtomic: amountAtomic,
+      verbose,
+    })
+  } else {
+    // Single check up front so we can surface a friendly error instead of
+    // letting `depositWithPermit` revert on insufficient balance.
+    const balance = await getUSDfcBalance({
+      address: owner,
+      chain: filecoinMainnet,
+    })
+    if (balance < amountAtomic) {
+      throw new Error(
+        `Insufficient USDfc on Filecoin for ${owner}: have ${Value.format(
+          balance,
+          18,
+        )}, need ${Value.format(amountAtomic, 18)}`,
+      )
+    }
+  }
+
+  logger.info(
+    `Depositing ${Value.format(amountAtomic, 18)} USDfc to Filecoin Pay`,
+  )
+
+  const alreadyApproved = await isFwssMaxApproved({
+    clientAddress: owner,
+    chain: filecoinMainnet,
+  })
+
+  const params = alreadyApproved
+    ? await depositWithPermitWriteParameters({
+        privateKey,
+        address: owner,
+        amount: amountAtomic,
+        chain: filecoinMainnet,
+      })
+    : await depositWithPermitAndApproveOperatorWriteParameters({
+        privateKey,
+        address: owner,
+        amount: amountAtomic,
+        chain: filecoinMainnet,
+      })
+
+  const depositHash = (await sendTransaction({
+    ...params,
+    chainId: filecoinMainnet.id,
+    privateKey,
+  })) as Hex
+
+  logger.info(`Deposit tx: ${FILECOIN_MAINNET.explorer}/tx/${depositHash}`)
+
+  await waitForTransaction(filProvider[filecoinMainnet.id], depositHash)
+  logger.success('Deposit confirmed')
+
+  return { depositTxHash: depositHash, depositedAmount: amountAtomic }
+}
+
+/**
+ * Poll Filecoin RPC until the address's USDfc balance reaches at least
+ * `minimumAtomic`. Used by the bridge → deposit handoff because Squid's
+ * relayer reports `success` as soon as the destination tx is mined, but some
+ * RPC providers lag by a few seconds before exposing the new balance.
+ */
+const waitForUsdfcBalance = async ({
+  address,
+  minimumAtomic,
+  maxAttempts = 60,
+  intervalMs = 10_000,
+  verbose,
+}: {
+  address: Address
+  minimumAtomic: bigint
+  maxAttempts?: number
+  intervalMs?: number
+  verbose?: boolean
+}): Promise<bigint> => {
+  for (let i = 0; i < maxAttempts; i++) {
+    const balance = await getUSDfcBalance({
+      address,
+      chain: filecoinMainnet,
+    })
+    if (balance >= minimumAtomic) return balance
+    if (verbose && i % 5 === 0) {
+      logger.info(
+        `Waiting for USDfc balance (have ${Value.format(balance, 18)}, need ${Value.format(minimumAtomic, 18)})`,
+      )
+    }
+    await setTimeout(intervalMs)
+  }
+  throw new Error(
+    `USDfc balance did not reach ${Value.format(minimumAtomic, 18)} within ${maxAttempts} polls`,
+  )
+}

--- a/test/actions/bridge.test.ts
+++ b/test/actions/bridge.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { topupAction } from '../../src/actions/topup.js'
+import { bridgeAction } from '../../src/actions/bridge.js'
 import {
   MissingCLIArgsError,
   MissingKeyError,
@@ -9,7 +9,7 @@ import {
 const DUMMY_PK =
   '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
 
-describe('topup action', () => {
+describe('bridge action', () => {
   let originalPk: string | undefined
 
   beforeEach(() => {
@@ -24,19 +24,19 @@ describe('topup action', () => {
 
   it('throws MissingCLIArgsError if amount is missing', async () => {
     await expect(
-      topupAction({ amount: '', options: { provider: 'AIOZ' } }),
+      bridgeAction({ amount: '', options: { provider: 'AIOZ' } }),
     ).rejects.toBeInstanceOf(MissingCLIArgsError)
   })
 
   it('throws MissingCLIArgsError if provider is missing', async () => {
     await expect(
-      topupAction({ amount: '1', options: {} }),
+      bridgeAction({ amount: '1', options: {} }),
     ).rejects.toBeInstanceOf(MissingCLIArgsError)
   })
 
   it('throws UnknownProviderError for unsupported providers', async () => {
     await expect(
-      topupAction({
+      bridgeAction({
         amount: '1',
         options: { provider: 'Pinata', 'from-chain': 'eth' },
       }),
@@ -45,7 +45,7 @@ describe('topup action', () => {
 
   it('throws MissingKeyError when OMNIPIN_PK is not set', async () => {
     await expect(
-      topupAction({
+      bridgeAction({
         amount: '1',
         options: { provider: 'AIOZ', 'from-chain': 'eth' },
       }),
@@ -55,7 +55,7 @@ describe('topup action', () => {
   it('throws MissingCLIArgsError for invalid --from-chain', async () => {
     process.env.OMNIPIN_PK = DUMMY_PK
     await expect(
-      topupAction({
+      bridgeAction({
         amount: '1',
         options: { provider: 'AIOZ', 'from-chain': 'polygon' },
       }),
@@ -65,7 +65,7 @@ describe('topup action', () => {
   it('throws MissingCLIArgsError if --from-chain is missing for AIOZ', async () => {
     process.env.OMNIPIN_PK = DUMMY_PK
     await expect(
-      topupAction({
+      bridgeAction({
         amount: '1',
         options: { provider: 'AIOZ' },
       }),
@@ -75,7 +75,7 @@ describe('topup action', () => {
   it('rejects non-positive amounts', async () => {
     process.env.OMNIPIN_PK = DUMMY_PK
     await expect(
-      topupAction({
+      bridgeAction({
         amount: '0',
         options: { provider: 'AIOZ', 'from-chain': 'eth' },
       }),
@@ -85,7 +85,7 @@ describe('topup action', () => {
   it('rejects malformed amounts', async () => {
     process.env.OMNIPIN_PK = DUMMY_PK
     await expect(
-      topupAction({
+      bridgeAction({
         amount: 'not-a-number',
         options: { provider: 'AIOZ', 'from-chain': 'eth' },
       }),
@@ -96,7 +96,7 @@ describe('topup action', () => {
     it('throws MissingCLIArgsError if --from-chain is missing', async () => {
       process.env.OMNIPIN_PK = DUMMY_PK
       await expect(
-        topupAction({
+        bridgeAction({
           amount: '1',
           options: { provider: 'Filecoin', 'from-token': 'USDC' },
         }),
@@ -106,7 +106,7 @@ describe('topup action', () => {
     it('throws MissingCLIArgsError for an unsupported --from-chain', async () => {
       process.env.OMNIPIN_PK = DUMMY_PK
       await expect(
-        topupAction({
+        bridgeAction({
           amount: '1',
           options: {
             provider: 'Filecoin',
@@ -120,7 +120,7 @@ describe('topup action', () => {
     it('throws MissingCLIArgsError if --from-token is missing', async () => {
       process.env.OMNIPIN_PK = DUMMY_PK
       await expect(
-        topupAction({
+        bridgeAction({
           amount: '1',
           options: { provider: 'Filecoin', 'from-chain': 'arb' },
         }),
@@ -130,7 +130,7 @@ describe('topup action', () => {
     it('rejects an out-of-range --fil-ratio', async () => {
       process.env.OMNIPIN_PK = DUMMY_PK
       await expect(
-        topupAction({
+        bridgeAction({
           amount: '1',
           options: {
             provider: 'Filecoin',
@@ -145,7 +145,7 @@ describe('topup action', () => {
     it('rejects a non-numeric --fil-ratio', async () => {
       process.env.OMNIPIN_PK = DUMMY_PK
       await expect(
-        topupAction({
+        bridgeAction({
           amount: '1',
           options: {
             provider: 'Filecoin',
@@ -160,7 +160,7 @@ describe('topup action', () => {
     it('rejects a non-positive --slippage', async () => {
       process.env.OMNIPIN_PK = DUMMY_PK
       await expect(
-        topupAction({
+        bridgeAction({
           amount: '1',
           options: {
             provider: 'Filecoin',
@@ -175,7 +175,7 @@ describe('topup action', () => {
     it('rejects a --slippage above the cap', async () => {
       process.env.OMNIPIN_PK = DUMMY_PK
       await expect(
-        topupAction({
+        bridgeAction({
           amount: '1',
           options: {
             provider: 'Filecoin',

--- a/test/actions/deposit.test.ts
+++ b/test/actions/deposit.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { depositAction } from '../../src/actions/deposit.js'
+import {
+  MissingCLIArgsError,
+  MissingKeyError,
+  UnknownProviderError,
+} from '../../src/errors.js'
+
+const DUMMY_PK =
+  '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
+
+describe('deposit action', () => {
+  let originalPk: string | undefined
+
+  beforeEach(() => {
+    originalPk = process.env.OMNIPIN_PK
+    delete process.env.OMNIPIN_PK
+  })
+
+  afterEach(() => {
+    if (originalPk === undefined) delete process.env.OMNIPIN_PK
+    else process.env.OMNIPIN_PK = originalPk
+  })
+
+  it('throws MissingCLIArgsError if amount is missing', async () => {
+    await expect(
+      depositAction({ amount: '', options: { provider: 'Filecoin' } }),
+    ).rejects.toBeInstanceOf(MissingCLIArgsError)
+  })
+
+  it('throws MissingCLIArgsError if provider is missing', async () => {
+    await expect(
+      depositAction({ amount: '1', options: {} }),
+    ).rejects.toBeInstanceOf(MissingCLIArgsError)
+  })
+
+  it('throws UnknownProviderError for unsupported providers', async () => {
+    await expect(
+      depositAction({ amount: '1', options: { provider: 'Pinata' } }),
+    ).rejects.toBeInstanceOf(UnknownProviderError)
+  })
+
+  it('throws UnknownProviderError for AIOZ (no deposit step)', async () => {
+    // AIOZ has no separate deposit contract — bridge is the whole flow.
+    await expect(
+      depositAction({ amount: '1', options: { provider: 'AIOZ' } }),
+    ).rejects.toBeInstanceOf(UnknownProviderError)
+  })
+
+  it('throws MissingKeyError when OMNIPIN_PK is not set', async () => {
+    await expect(
+      depositAction({ amount: '1', options: { provider: 'Filecoin' } }),
+    ).rejects.toBeInstanceOf(MissingKeyError)
+  })
+
+  it('rejects non-positive amounts', async () => {
+    process.env.OMNIPIN_PK = DUMMY_PK
+    await expect(
+      depositAction({ amount: '0', options: { provider: 'Filecoin' } }),
+    ).rejects.toThrow(/must be positive/)
+  })
+
+  it('rejects malformed amounts', async () => {
+    process.env.OMNIPIN_PK = DUMMY_PK
+    await expect(
+      depositAction({
+        amount: 'not-a-number',
+        options: { provider: 'Filecoin' },
+      }),
+    ).rejects.toThrow(/Invalid amount/)
+  })
+})

--- a/test/utils/filecoin-bridge.test.ts
+++ b/test/utils/filecoin-bridge.test.ts
@@ -4,10 +4,10 @@ import {
   isSourceChainKey,
   resolveSourceToken,
   SOURCE_CHAINS,
-} from '../../src/utils/filecoin-topup.js'
+} from '../../src/utils/filecoin-bridge.js'
 import { NATIVE_TOKEN } from '../../src/utils/squid.js'
 
-describe('filecoin-topup utils', () => {
+describe('filecoin-bridge utils', () => {
   describe('SOURCE_CHAINS', () => {
     it('contains the seven allow-listed chains', () => {
       expect(Object.keys(SOURCE_CHAINS).sort()).toEqual(


### PR DESCRIPTION
Replaces the single `omnipin topup` command with two more orthogonal commands:

- **`omnipin bridge`** handles cross-chain bridging only (AIOZ + Filecoin). It stops once the bridged funds land in the destination wallet.
- **`omnipin deposit`** is Filecoin-only and moves already-held USDfc on Filecoin into Filecoin Pay (the storage payment contract).

This lets users who already have USDfc on Filecoin (bought directly via SushiSwap, OTC, calibnet faucet, etc.) skip the bridge entirely and just deposit. The previous `topup` behaviour is now achieved by running `bridge` followed by `deposit`.

## New CLI shape

```sh
# Cross-chain bridge only. Stops when funds land in destination wallet.
omnipin bridge --provider=AIOZ     --from-chain=eth <amount> [--to=<addr>]
omnipin bridge --provider=Filecoin --from-chain=arb --from-token=USDC <amount> [--to=<addr>] [--fil-ratio=0.1] [--slippage=1]

# Deposit existing USDfc on Filecoin into Filecoin Pay (no bridging).
omnipin deposit --provider=Filecoin <usdfc-amount> [--from=<addr>]
```

The full previous flow is now two commands:

```sh
omnipin bridge  --provider=Filecoin --from-chain=arb --from-token=USDC 10
omnipin deposit --provider=Filecoin 9
```

## Design notes

- **`bridge` for Filecoin no longer auto-deposits.** The `waitForUsdfcBalance` poll moved into `depositFilecoinUsdfc` (controlled by an internal `waitForBalance` flag; defaults to `false` so direct `deposit` invocations error fast on insufficient balance instead of polling).
- **`deposit` requires an explicit amount** — no `--max`. Checks wallet balance up front and errors with a friendly message if insufficient, rather than letting the on-chain `depositWithPermit` revert.
- **`deposit` rejects AIOZ** with `UnknownProviderError` — there's no separate deposit step on AIOZ Network. Documented this in `docs/cli/deposit.md`.
- The first-time-vs-subsequent FilPay path (`depositWithPermit` vs `depositWithPermitAndApproveOperator`) is preserved exactly as before.

## File changes

| Change | Files |
|---|---|
| Rename `topupAioz` → `bridgeAioz` | `src/utils/aioz-bridge.ts` |
| Split bridge & deposit logic | `src/utils/filecoin-topup.ts` → `filecoin-bridge.ts` (bridge only) + new `src/utils/filecoin-deposit.ts` |
| New action files | `src/actions/topup.ts` → `bridge.ts` + new `deposit.ts` |
| CLI commands | `src/cli.ts`: drop `topup`, add `bridge` + `deposit` |
| Docs | `docs/cli/topup.md` → `bridge.md` + new `deposit.md`; updated `docs/docs/ipfs.md`; added both to vitepress sidebar |
| Tests | `test/actions/topup.test.ts` → `bridge.test.ts` + new `deposit.test.ts`; renamed `test/utils/filecoin-topup.test.ts` → `filecoin-bridge.test.ts` |

## Verification

- `bun run types` — no new errors (3 pre-existing in `test/providers/aioz.test.ts` unrelated to this change).
- `bun run check` — clean (warnings pre-existing).
- `bun run build` — succeeds.
- `bun test` — all 42 bridge+deposit tests pass; the 1 pre-existing fail/1 error are the unrelated `ipfs-ninja` env-var check.

## Breaking change

`omnipin topup` is removed. Users on the current `topup` Filecoin flow should switch to:

```sh
# before
omnipin topup --provider=Filecoin --from-chain=arb --from-token=USDC 10

# after
omnipin bridge  --provider=Filecoin --from-chain=arb --from-token=USDC 10
omnipin deposit --provider=Filecoin 9
```
