### PR TITLE
fix: exit non-zero when all providers fail in deploy/pin

### DIFF
--- a/src/actions/deploy.ts
+++ b/src/actions/deploy.ts
@@ -1,6 +1,6 @@
 import { isTTY, PROVIDERS } from '../constants.js'
 import { AsciiBar, styleText } from '../deps.js'
-import { NoProvidersError } from '../errors.js'
+import { AllProvidersFailedError, NoProvidersError } from '../errors.js'
 import {
   findEnvVarProviderName,
   parseTokensFromEnv,
@@ -189,7 +189,7 @@ export const deployAction = async ({
     errors.forEach((e) => {
       logger.error(e)
     })
-    return
+    throw new AllProvidersFailedError('deploy', errors)
   } else if (errors.length) {
     logger.warn('There were some problems with deploying')
     errors.forEach((e) => {

--- a/src/actions/pin.ts
+++ b/src/actions/pin.ts
@@ -1,6 +1,6 @@
 import { isTTY, PROVIDERS } from '../constants.js'
 import { AsciiBar } from '../deps.js'
-import { NoProvidersError } from '../errors.js'
+import { AllProvidersFailedError, NoProvidersError } from '../errors.js'
 import {
   findEnvVarProviderName,
   parseTokensFromEnv,
@@ -86,7 +86,7 @@ export const pinAction = async ({
     errors.forEach((e) => {
       logger.error(e)
     })
-    return
+    throw new AllProvidersFailedError('pin', errors)
   } else if (errors.length) {
     logger.warn('There were some problems with pinning')
     errors.forEach((e) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,8 @@ import { pingAction } from './actions/ping.js'
 import { statusAction } from './actions/status.js'
 import { zodiacAction } from './actions/zodiac.js'
 import { isTTY } from './constants.js'
+import { AllProvidersFailedError } from './errors.js'
+import { logger } from './utils/logger.js'
 
 const cli = new CLI({ name: 'omnipin', plugins: isTTY ? [colorPlugin] : [] })
 
@@ -375,4 +377,19 @@ cli.command<[Address, Address]>(
 )
 
 cli.help()
-cli.handle(process.argv.slice(2))
+
+// Surface action errors as a non-zero exit code without dumping an
+// "UnhandledPromiseRejection" traceback. AllProvidersFailedError has already
+// logged each underlying error in the action itself; for anything else, log
+// the message before exiting.
+process.on('unhandledRejection', (err) => {
+  if (!(err instanceof AllProvidersFailedError)) logger.error(err)
+  process.exitCode = 1
+})
+
+try {
+  cli.handle(process.argv.slice(2))
+} catch (err) {
+  if (!(err instanceof AllProvidersFailedError)) logger.error(err)
+  process.exitCode = 1
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -53,6 +53,18 @@ export class NoProvidersError extends Error {
   }
 }
 
+export class AllProvidersFailedError extends AggregateError {
+  name = 'AllProvidersFailedError'
+  operation: 'deploy' | 'pin'
+  constructor(operation: 'deploy' | 'pin', errors: Error[]) {
+    super(
+      errors,
+      `${operation === 'deploy' ? 'Deploy' : 'Pinning'} failed on all providers.`,
+    )
+    this.operation = operation
+  }
+}
+
 export class MissingKeyError extends Error {
   name = 'MissingKeyError'
   constructor(key: string) {

--- a/test/actions/deploy.test.ts
+++ b/test/actions/deploy.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { deployAction } from '../../src/actions/deploy.js'
+import { PROVIDERS } from '../../src/constants.js'
+import { AllProvidersFailedError } from '../../src/errors.js'
+
+describe('deploy action', () => {
+  let originalBeeToken: string | undefined
+  let originalBeeUpload: typeof PROVIDERS.BEE_TOKEN.upload
+
+  beforeEach(() => {
+    originalBeeToken = process.env.OMNIPIN_BEE_TOKEN
+    process.env.OMNIPIN_BEE_TOKEN = 'test-token'
+    originalBeeUpload = PROVIDERS.BEE_TOKEN.upload
+  })
+
+  afterEach(() => {
+    if (originalBeeToken === undefined) delete process.env.OMNIPIN_BEE_TOKEN
+    else process.env.OMNIPIN_BEE_TOKEN = originalBeeToken
+    PROVIDERS.BEE_TOKEN.upload = originalBeeUpload
+  })
+
+  it('throws AllProvidersFailedError when every provider fails', async () => {
+    PROVIDERS.BEE_TOKEN.upload = async () => {
+      throw new TypeError('fetch failed')
+    }
+
+    await expect(
+      deployAction({
+        dir: 'test/fixtures/walk',
+        options: { 'progress-bar': false },
+      }),
+    ).rejects.toBeInstanceOf(AllProvidersFailedError)
+  })
+
+  it('AllProvidersFailedError exposes the underlying errors via AggregateError', async () => {
+    const cause = new TypeError('fetch failed')
+    PROVIDERS.BEE_TOKEN.upload = async () => {
+      throw cause
+    }
+
+    try {
+      await deployAction({
+        dir: 'test/fixtures/walk',
+        options: { 'progress-bar': false },
+      })
+      throw new Error('deployAction should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(AllProvidersFailedError)
+      const aggregate = err as AllProvidersFailedError
+      expect(aggregate.operation).toBe('deploy')
+      expect(aggregate.errors).toContain(cause)
+    }
+  })
+
+  it('rethrows immediately in strict mode', async () => {
+    const cause = new TypeError('fetch failed')
+    PROVIDERS.BEE_TOKEN.upload = async () => {
+      throw cause
+    }
+
+    await expect(
+      deployAction({
+        dir: 'test/fixtures/walk',
+        options: { strict: true, 'progress-bar': false },
+      }),
+    ).rejects.toBe(cause)
+  })
+})

--- a/test/actions/pin.test.ts
+++ b/test/actions/pin.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { pinAction } from '../../src/actions/pin.js'
+import { PROVIDERS } from '../../src/constants.js'
+import { AllProvidersFailedError } from '../../src/errors.js'
+
+const DUMMY_CID = 'bafybeibwzif3z6vjyz5fr4xj4exadgz3y3qhrhqycnf6jb6e2pwpgqaa3a'
+
+describe('pin action', () => {
+  let originalPinataToken: string | undefined
+  let originalPinataUpload: typeof PROVIDERS.PINATA_TOKEN.upload
+
+  beforeEach(() => {
+    originalPinataToken = process.env.OMNIPIN_PINATA_TOKEN
+    process.env.OMNIPIN_PINATA_TOKEN = 'test-token'
+    originalPinataUpload = PROVIDERS.PINATA_TOKEN.upload
+  })
+
+  afterEach(() => {
+    if (originalPinataToken === undefined)
+      delete process.env.OMNIPIN_PINATA_TOKEN
+    else process.env.OMNIPIN_PINATA_TOKEN = originalPinataToken
+    PROVIDERS.PINATA_TOKEN.upload = originalPinataUpload
+  })
+
+  it('throws AllProvidersFailedError when every provider fails', async () => {
+    PROVIDERS.PINATA_TOKEN.upload = async () => {
+      throw new TypeError('fetch failed')
+    }
+
+    await expect(
+      pinAction({ cid: DUMMY_CID, options: {} }),
+    ).rejects.toBeInstanceOf(AllProvidersFailedError)
+  })
+
+  it('AllProvidersFailedError exposes operation "pin" and underlying errors', async () => {
+    const cause = new TypeError('fetch failed')
+    PROVIDERS.PINATA_TOKEN.upload = async () => {
+      throw cause
+    }
+
+    try {
+      await pinAction({ cid: DUMMY_CID, options: {} })
+      throw new Error('pinAction should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(AllProvidersFailedError)
+      const aggregate = err as AllProvidersFailedError
+      expect(aggregate.operation).toBe('pin')
+      expect(aggregate.errors).toContain(cause)
+    }
+  })
+
+  it('rethrows immediately in strict mode', async () => {
+    const cause = new TypeError('fetch failed')
+    PROVIDERS.PINATA_TOKEN.upload = async () => {
+      throw cause
+    }
+
+    await expect(
+      pinAction({ cid: DUMMY_CID, options: { strict: true } }),
+    ).rejects.toBe(cause)
+  })
+})


### PR DESCRIPTION
Previously, when every provider failed during 'omnipin deploy' or 'omnipin pin', the action logged the per-provider errors and silently returned. The CLI process then exited 0, so a broken deployment (e.g. Bee node unreachable) showed up as a green CI run.

Throw a new AllProvidersFailedError (extends AggregateError) from the all-failed branch in both actions, and add a top-level handler in cli.ts that maps any uncaught action error to process.exitCode = 1 without dumping an UnhandledPromiseRejection trace. AllProvidersFailedError is treated specially since its underlying errors are already logged by the action.

Includes unit tests for both actions covering the all-failed, AggregateError, and strict-mode rethrow paths.