### PR TITLE
fix: exit non-zero when all providers fail in deploy/pin

### DIFF
--- a/src/actions/deploy.ts
+++ b/src/actions/deploy.ts
@@ -1,6 +1,6 @@
 import { isTTY, PROVIDERS } from '../constants.js'
 import { AsciiBar, styleText } from '../deps.js'
-import { NoProvidersError } from '../errors.js'
+import { AllProvidersFailedError, NoProvidersError } from '../errors.js'
 import {
   findEnvVarProviderName,
   parseTokensFromEnv,
@@ -189,7 +189,7 @@ export const deployAction = async ({
     errors.forEach((e) => {
       logger.error(e)
     })
-    return
+    throw new AllProvidersFailedError('deploy', errors)
   } else if (errors.length) {
     logger.warn('There were some problems with deploying')
     errors.forEach((e) => {

--- a/src/actions/pin.ts
+++ b/src/actions/pin.ts
@@ -1,6 +1,6 @@
 import { isTTY, PROVIDERS } from '../constants.js'
 import { AsciiBar } from '../deps.js'
-import { NoProvidersError } from '../errors.js'
+import { AllProvidersFailedError, NoProvidersError } from '../errors.js'
 import {
   findEnvVarProviderName,
   parseTokensFromEnv,
@@ -86,7 +86,7 @@ export const pinAction = async ({
     errors.forEach((e) => {
       logger.error(e)
     })
-    return
+    throw new AllProvidersFailedError('pin', errors)
   } else if (errors.length) {
     logger.warn('There were some problems with pinning')
     errors.forEach((e) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,8 @@ import { pingAction } from './actions/ping.js'
 import { statusAction } from './actions/status.js'
 import { zodiacAction } from './actions/zodiac.js'
 import { isTTY } from './constants.js'
+import { AllProvidersFailedError } from './errors.js'
+import { logger } from './utils/logger.js'
 
 const cli = new CLI({ name: 'omnipin', plugins: isTTY ? [colorPlugin] : [] })
 
@@ -375,4 +377,19 @@ cli.command<[Address, Address]>(
 )
 
 cli.help()
-cli.handle(process.argv.slice(2))
+
+// Surface action errors as a non-zero exit code without dumping an
+// "UnhandledPromiseRejection" traceback. AllProvidersFailedError has already
+// logged each underlying error in the action itself; for anything else, log
+// the message before exiting.
+process.on('unhandledRejection', (err) => {
+  if (!(err instanceof AllProvidersFailedError)) logger.error(err)
+  process.exitCode = 1
+})
+
+try {
+  cli.handle(process.argv.slice(2))
+} catch (err) {
+  if (!(err instanceof AllProvidersFailedError)) logger.error(err)
+  process.exitCode = 1
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -53,6 +53,18 @@ export class NoProvidersError extends Error {
   }
 }
 
+export class AllProvidersFailedError extends AggregateError {
+  name = 'AllProvidersFailedError'
+  operation: 'deploy' | 'pin'
+  constructor(operation: 'deploy' | 'pin', errors: Error[]) {
+    super(
+      errors,
+      `${operation === 'deploy' ? 'Deploy' : 'Pinning'} failed on all providers.`,
+    )
+    this.operation = operation
+  }
+}
+
 export class MissingKeyError extends Error {
   name = 'MissingKeyError'
   constructor(key: string) {


### PR DESCRIPTION
## Problem

When every provider failed during `omnipin deploy` or `omnipin pin`, the action logged the per-provider errors and silently `return`ed. The CLI process then exited with code 0, so a fully-broken deployment (e.g. Bee node unreachable, `ECONNREFUSED`) showed up as a **green** CI run.

Real example: https://github.com/omnipin/omnipin/actions/runs/26340158981/job/77540652004 — the remote `omnipin deploy` printed `🚨 Deploy failed` + `TypeError: fetch failed` (`ECONNREFUSED`), yet the SSH step and the whole workflow finished with success.

## Fix

- New `AllProvidersFailedError extends AggregateError` in `src/errors.ts`. Carries `operation: 'deploy' | 'pin'` and the per-provider errors via `AggregateError.errors`.
- `deployAction` and `pinAction` now `throw new AllProvidersFailedError(...)` instead of silently `return`ing when every provider in the active path failed. The pre-existing `🚨 Deploy failed` / `🚨 Pinning failed` plus per-error logs are preserved — output is unchanged.
- `cli.ts` gains a top-level handler that maps any uncaught action error to `process.exitCode = 1` without dumping an `UnhandledPromiseRejection` traceback. `AllProvidersFailedError` is recognized so we don't double-log (the action already printed each underlying error).
- The partial-failure branch (`else if (errors.length)`) is unchanged — partial failures still log a warning and the deploy is considered successful, matching existing behavior.

## Verification

Built `dist/index.js` from this branch and reproduced the original CI scenario locally:

```
OMNIPIN_BEE_TOKEN=bogus BEE_URL=http://127.0.0.1:65500 \
  node dist/index.js deploy
→ 🟢 Deploying with providers: Bee
→ 📦 Packing dist (3B)
→ 🟢 TAR: /tmp/dist.tar
→ 🚨 Deploy failed
→ 🚨 [TypeError: fetch failed] { [cause]: AggregateError [ECONNREFUSED]: ... }
→ exit=1
```

Previously this same invocation printed identical output but exited 0.

`bun run types` and `bun run build` are clean; `bun run check` introduces no new warnings.