### PR TITLE
fix(safe): use JSON.stringify replacer instead of patching BigInt.prototype

### DIFF
--- a/src/utils/safe/propose.ts
+++ b/src/utils/safe/propose.ts
@@ -20,28 +20,24 @@ export const proposeTransaction = async ({
   senderSignature: Hex
   chainId: number
 }): Promise<void> => {
-  // In order to serialize BigInt
-  Object.defineProperty(BigInt.prototype, 'toJSON', {
-    get() {
-      return () => String(this)
-    },
-  })
-
   const res = await fetch(
     `${chainToSafeApiUrl(chainName)}/api/v1/safes/${safeAddress}/multisig-transactions/`,
     {
       method: 'POST',
-      body: JSON.stringify({
-        ...txData,
-        contractTransactionHash: safeTxHash,
-        sender: checksum(address),
-        signature: senderSignature,
-        origin: 'Omnipin',
-        value: 0n,
-        baseGas: txData.baseGas ?? 0n,
-        gasPrice: txData.gasPrice ?? 0n,
-        safeTxGas: txData.safeTxGas ?? 0n,
-      }),
+      body: JSON.stringify(
+        {
+          ...txData,
+          contractTransactionHash: safeTxHash,
+          sender: checksum(address),
+          signature: senderSignature,
+          origin: 'Omnipin',
+          value: 0n,
+          baseGas: txData.baseGas ?? 0n,
+          gasPrice: txData.gasPrice ?? 0n,
+          safeTxGas: txData.safeTxGas ?? 0n,
+        },
+        (_, v) => (typeof v === 'bigint' ? v.toString() : v),
+      ),
       headers: {
         'Content-Type': 'application/json',
       },


### PR DESCRIPTION
## Problem

`proposeTransaction` (the Safe multi-sig proposal helper) used to define a `toJSON` getter on `BigInt.prototype` on every call:

```ts
Object.defineProperty(BigInt.prototype, 'toJSON', {
  get() {
    return () => String(this)
  },
})
```

Two issues:

1. **Crashes on the second call.** `defineProperty` was called without `configurable: true`, so the second `proposeTransaction` invocation in the same process throws `TypeError: Cannot redefine property: toJSON`. Anyone proposing more than one ENS Content-Hash update via Safe in a single CLI run hits this.
2. **Global side effect.** It mutates `BigInt.prototype` for the entire process, leaking into any other code that ever `JSON.stringify`s a bigint.

## Fix

Pass a replacer function to `JSON.stringify` so the bigint → string coercion is scoped to the one payload that needs it:

```ts
JSON.stringify(payload, (_, v) => (typeof v === 'bigint' ? v.toString() : v))
```

- No global mutation.
- Idempotent across multiple calls.
- Smallest possible diff at the call site.

## Verification

- `bun run types` passes.
- Behaviorally identical for the API request body (bigints still serialize as decimal strings, which is what the Safe Transaction Service expects).
- Cross-checked against MDN's [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) replacer spec:
  - The replacer is called for the initial object with `key === ""` (passes the object through unchanged).
  - It's then called recursively for every property; bigint properties are replaced with their decimal string.
  - Returning a string from the replacer is the correct way to serialize as a JSON string (returning a bigint would itself throw).
  - No interaction with `toJSON` since the prototype patch is gone.
