### PR TITLE
fix(ipfs): preserve original block codec when writing CAR

### DIFF
--- a/src/utils/ipfs/blockstore.ts
+++ b/src/utils/ipfs/blockstore.ts
@@ -8,16 +8,19 @@ import type {
 import { NotFoundError } from 'interface-store'
 import all from 'it-all'
 import { base32 } from 'multiformats/bases/base32'
-import { CID } from 'multiformats/cid'
-import * as raw from 'multiformats/codecs/raw'
-import * as Digest from 'multiformats/hashes/digest'
+import type { CID } from 'multiformats/cid'
 
 function isPromise<T>(p?: any): p is Promise<T> {
   return typeof p?.then === 'function'
 }
 
+type Entry = {
+  cid: CID
+  bytes: Uint8Array[]
+}
+
 export class MemoryBlockstore implements Blockstore {
-  private readonly data: Map<string, Uint8Array[]>
+  private readonly data: Map<string, Entry>
 
   constructor() {
     this.data = new Map()
@@ -88,20 +91,20 @@ export class MemoryBlockstore implements Blockstore {
   ): Await<CID> {
     options?.signal?.throwIfAborted()
 
-    this.data.set(base32.encode(key.multihash.bytes), val)
+    this.data.set(base32.encode(key.multihash.bytes), { cid: key, bytes: val })
 
     return key
   }
 
   *get(key: CID, options?: AbortOptions): AwaitGenerator<Uint8Array> {
     options?.signal?.throwIfAborted()
-    const buf = this.data.get(base32.encode(key.multihash.bytes))
+    const entry = this.data.get(base32.encode(key.multihash.bytes))
 
-    if (buf == null) {
+    if (entry == null) {
       throw new NotFoundError()
     }
 
-    yield* buf
+    yield* entry.bytes
   }
 
   has(key: CID, options?: AbortOptions): Await<boolean> {
@@ -121,11 +124,11 @@ export class MemoryBlockstore implements Blockstore {
   *getAll(options?: AbortOptions): AwaitGenerator<Pair> {
     options?.signal?.throwIfAborted()
 
-    for (const [key, value] of this.data.entries()) {
+    for (const { cid, bytes } of this.data.values()) {
       yield {
-        cid: CID.createV1(raw.code, Digest.decode(base32.decode(key))),
+        cid,
         bytes: (async function* () {
-          yield* value
+          yield* bytes
         })(),
       }
       options?.signal?.throwIfAborted()

--- a/test/utils/ipfs.test.ts
+++ b/test/utils/ipfs.test.ts
@@ -1,5 +1,7 @@
 import { describe, it } from 'bun:test'
 import * as assert from 'node:assert'
+import { CarReader } from '@ipld/car/reader'
+import * as dagPb from '@ipld/dag-pb'
 import { assertCID, packCAR } from '../../src/utils/ipfs.js'
 
 const te = new TextEncoder()
@@ -27,6 +29,64 @@ describe('ipfs utils', () => {
       assert.ok(bytes instanceof Uint8Array)
       assert.ok(rootCID)
       assert.ok(rootCID.toString().startsWith('bafy'))
+    })
+
+    it('writes blocks under their importer-assigned codec', async () => {
+      // Regression test for the MemoryBlockstore.getAll() bug where every
+      // block was rebuilt as `CID.createV1(raw.code, multihash)`, regardless
+      // of whether the UnixFS importer originally assigned dag-pb (for
+      // directories and chunked-file roots) or raw (for leaf chunks).
+      //
+      // Before the fix, the CAR's declared root was a dag-pb CID
+      // (`bafybei…`) but the block in the CAR with the matching multihash
+      // was written as a raw CID (`bafkrei…`), so `reader.has(rootCID)`
+      // returned false — the CAR could not resolve its own root.
+      //
+      // We use a file >256KB so the importer chunks it: that path
+      // produces both raw leaf blocks and a dag-pb intermediate root for
+      // the chunked file, exercising the mixed-codec case end-to-end.
+      const files = [
+        { path: 'index.html', content: te.encode('<html>hi</html>') },
+        { path: 'sub/big.bin', content: new Uint8Array(400 * 1024) },
+      ]
+
+      const { bytes, rootCID } = await packCAR(files, 'codec-regression')
+      const reader = await CarReader.fromBytes(bytes)
+
+      // The root CID declared in the CAR header must be a dag-pb CID
+      // (wrapping directory) and must be present as a block inside the
+      // CAR itself.
+      assert.strictEqual(rootCID.code, dagPb.code, 'root CID should be dag-pb')
+      assert.ok(
+        await reader.has(rootCID),
+        'CAR must contain a block for its own declared root CID',
+      )
+
+      // And that block's bytes must actually parse as dag-pb (i.e. the
+      // codec field in the CID matches the encoded payload).
+      const rootBlock = await reader.get(rootCID)
+      assert.ok(rootBlock)
+      const decoded = dagPb.decode(rootBlock.bytes)
+      assert.strictEqual(
+        decoded.Links?.length,
+        2,
+        'wrapping directory should link to index.html and sub/',
+      )
+
+      // The CAR should contain a mix of dag-pb and raw blocks. Pre-fix
+      // it contained raw blocks only.
+      const codecs = new Set<number>()
+      for await (const block of reader.blocks()) {
+        codecs.add(block.cid.code)
+      }
+      assert.ok(
+        codecs.has(dagPb.code),
+        'CAR should contain at least one dag-pb block (directory / chunked-file root)',
+      )
+      assert.ok(
+        codecs.has(0x55),
+        'CAR should contain at least one raw block (file leaf chunk)',
+      )
     })
   })
 


### PR DESCRIPTION
## Background — what's wrong, and what's *not* wrong

Per the [CARv1 spec](https://ipld.io/specs/transport/car/carv1/), the `roots` array in the CAR header **SHOULD** contain CIDs that appear as blocks in the body, with the block's CID codec matching the encoded payload. `MemoryBlockstore.getAll()` violated this by rebuilding every block's CID with a hardcoded `raw` codec, regardless of what the UnixFS importer originally assigned:

```ts
yield {
  cid: CID.createV1(raw.code, Digest.decode(base32.decode(key))),
  …
}
```

The UnixFS importer assigns codecs per-block: `dag-pb` (`0x70`) for directories and chunked-file roots, `raw` (`0x55`) for leaf chunks. Discarding the original codec produces a CAR where every block is written under a `bafkrei…` (raw) CID, while the declared root is `bafybei…` (dag-pb) — same multihash, different codec prefix.

## Why nothing's been broken in practice

Importantly, **Omnipin's existing CARs are not rejected anywhere in the wild**. The CARv1 spec itself notes:

> #### Root CID block existence
> It is unresolved whether an implementation must verify that a CID present in the roots array of the Header also appears as a block in the archive. […] **Current implementations of this version of the CAR specification *do not* check for root block existence in the CAR body.**

Three independent reasons existing deployments work fine:

1. **Pinning services (Pinata, Lighthouse, Filebase, IPFSNinja)** re-import the CAR through their own UnixFS pipeline, recompute fresh CIDs from byte content, and produce a correctly-coded `dag-pb` root. The CIDs encoded inside the CAR are effectively discarded.
2. **IPFS gateways** resolve the published `bafybei…` via bitswap / DHT against the network, not against this specific CAR. The bytes that hash to the root's multihash are already on the network under the right CID (because of #1).
3. **Filecoin SPs** verify the Piece CID (commP), which is computed from the raw CAR bytes — independent of any per-block CID codec. The deal is internally consistent.

So this PR fixes a **CARv1 SHOULD violation** with no observable behavior change for current consumers.

## What this PR does change

- The CAR is now spec-conforming: declared root appears as a block whose codec field matches its content.
- The CAR byte layout changes (block-CID prefixes inside the CAR differ for 3 of the 6 blocks in a typical small site).
- As a downstream consequence, the **Filecoin Piece CID changes** for the same input directory, since commP is computed over the CAR bytes. Existing on-chain deals are unaffected, but new deals will compute different commPs than they would have pre-fix.

This is worth taking before v3 because:
1. The current output is technically non-conforming with the spec.
2. Any future consumer that *does* validate codec/CID consistency (e.g. strict trustless-gateway clients, IPLD-aware verification tools) would fail against today's CARs.
3. The change is 14 lines in one file with no API surface impact.

## Repro

```sh
$ cd /tmp && mkdir -p codec-e2e/sub
$ echo '<html>hi</html>' > codec-e2e/index.html
$ dd if=/dev/urandom of=codec-e2e/sub/big.bin bs=1024 count=400
$ bun /path/to/src/cli.ts pack codec-e2e -n codec-e2e -d /tmp
🟢 Root CID: bafybeidqpf3udtxbaulsuifpcwkvsu47wdaylje7ayornoaigchpgdn5na
```

Then inspecting the CAR:

```js
const reader = await CarReader.fromBytes(await readFile('/tmp/codec-e2e.car'))
const [root] = await reader.getRoots()
console.log(root.toString())          // bafybei… (codec 0x70)
console.log(await reader.has(root))   // false (pre-fix), true (post-fix)

for await (const b of reader.blocks()) console.log(b.cid.code)
// pre-fix:  all 0x55 (raw)
// post-fix: mix of 0x55 (raw leaves) and 0x70 (dag-pb directory + chunked-file root)
```

## Fix

Store the original `CID` alongside the bytes in the backing map, and yield it unchanged from `getAll()`. The change touches `MemoryBlockstore` only; no API change for callers.

## Verification

Regression test added in `test/utils/ipfs.test.ts` — packs a directory containing both small files and a >256KB file (to force chunking, which produces the dag-pb chunked-file root + raw leaf chunks), then asserts:

- `rootCID.code === dagPb.code`
- `reader.has(rootCID)` is `true`
- The root block decodes as dag-pb with the expected link count
- The CAR contains both `raw` and `dag-pb` blocks

End-to-end tested against IPFSNinja using `bun --env-file=.env.local src/cli.ts deploy …`. Subpath resolution through dweb.link works and a 512KB chunked binary asset round-trips byte-exact:

```sh
$ md5sum /tmp/data-rt.bin /tmp/codec-e2e-deploy/assets/data.bin
1651b76cd8b010261dc23ec4690f88dd  /tmp/data-rt.bin
1651b76cd8b010261dc23ec4690f88dd  /tmp/codec-e2e-deploy/assets/data.bin
```

`bun run types` and `bun test test/utils/ipfs.test.ts` both pass. The new test fails cleanly on `main` with `AssertionError: CAR must contain a block for its own declared root CID`.
