### PR TITLE
refactor(providers): pass Uint8Array directly to Blob/File

### DIFF
--- a/src/providers/ipfs/lighthouse.ts
+++ b/src/providers/ipfs/lighthouse.ts
@@ -17,9 +17,7 @@ export const uploadOnLighthouse: UploadFunction = async ({
 
     fd.append(
       'file',
-      new Blob([Uint8Array.from(bytes).buffer], {
-        type: 'application/vnd.ipld.car',
-      }),
+      new Blob([bytes], { type: 'application/vnd.ipld.car' }),
       `${name}.car`,
     )
 

--- a/src/providers/ipfs/pinata.ts
+++ b/src/providers/ipfs/pinata.ts
@@ -20,12 +20,7 @@ export const uploadOnPinata: UploadFunction = async ({
   if (first) {
     const fd = new FormData()
 
-    fd.append(
-      'file',
-      new Blob([bytes.buffer as ArrayBuffer], {
-        type: 'application/vnd.ipld.car',
-      }),
-    )
+    fd.append('file', new Blob([bytes], { type: 'application/vnd.ipld.car' }))
     fd.append('network', 'public')
 
     fd.append('name', `${name}.car`)

--- a/src/providers/ipfs/s3.ts
+++ b/src/providers/ipfs/s3.ts
@@ -19,7 +19,7 @@ export const uploadOnS3 = async ({
   }>,
   'first' | 'cid'
 >): Promise<Response> => {
-  const file = new File([bytes.buffer as ArrayBuffer], name, {
+  const file = new File([bytes], name, {
     type: 'application/vnd.ipld.car',
   })
 

--- a/src/providers/ipfs/simplepage.ts
+++ b/src/providers/ipfs/simplepage.ts
@@ -11,7 +11,7 @@ export const uploadToSimplePage: UploadFunction = async ({
   const fd = new FormData()
   fd.append(
     'file',
-    new File([bytes.buffer as ArrayBuffer], `${name}.car`, {
+    new File([bytes], `${name}.car`, {
       type: 'application/vnd.ipld.car',
     }),
   )

--- a/src/providers/swarm/bee.ts
+++ b/src/providers/swarm/bee.ts
@@ -16,7 +16,7 @@ export const uploadOnBee: UploadFunction<{ beeURL?: string }> = async ({
 }) => {
   if (!first) throw new PinningNotSupportedError(providerName)
   const res = await fetch(`${beeURL}/bzz`, {
-    body: new Blob([bytes.buffer as ArrayBuffer]),
+    body: new Blob([bytes]),
     headers: {
       'Swarm-Postage-Batch-Id': token,
       'Content-Type': 'application/x-tar',

--- a/src/providers/swarm/swarmy.ts
+++ b/src/providers/swarm/swarmy.ts
@@ -13,7 +13,7 @@ export const uploadOnSwarmy: UploadFunction = async ({
 }) => {
   if (!first) throw new PinningNotSupportedError(providerName)
   const body = new FormData()
-  body.append('file', new Blob([bytes.buffer as ArrayBuffer]))
+  body.append('file', new Blob([bytes]))
   const res = await fetch('https://api.swarmy.cloud/api/files?website=true', {
     body,
     headers: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,9 @@ type AuthArgs = {
 export type UploadArgs<T = object> = {
   name: string
   verbose?: boolean
-  bytes: Uint8Array
+  // Pin to `ArrayBuffer` (not `ArrayBufferLike`) so the buffer is usable
+  // directly as a `BlobPart` / `BodyInit` without casts.
+  bytes: Uint8Array<ArrayBuffer>
   first: boolean
   size: number
   cid: string

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -29,7 +29,7 @@ export const packCAR = async (
   files: FileCandidate[],
   name: string,
   dir = tmp,
-): Promise<{ bytes: Uint8Array; rootCID: CID }> => {
+): Promise<{ bytes: Uint8Array<ArrayBuffer>; rootCID: CID }> => {
   const output = `${dir}/${name}.car`
 
   const blockstore = new MemoryBlockstore()
@@ -76,7 +76,11 @@ export const packCAR = async (
   await new Promise<void>((resolve) => writeStream.on('close', resolve))
 
   const file = await readFile(output)
-  const bytes = file as Uint8Array
+  // `readFile` returns a Node `Buffer` whose underlying type widens to
+  // `Uint8Array<ArrayBufferLike>`. We know the returned buffer is backed by
+  // a plain ArrayBuffer (not SharedArrayBuffer), so narrow it explicitly so
+  // callers can hand `bytes` to `Blob` / `File` without extra casts.
+  const bytes = file as Uint8Array<ArrayBuffer>
 
   blockstore.clear()
 


### PR DESCRIPTION
## Why

All six provider upload paths built their `Blob` / `File` via `new Blob([bytes.buffer as ArrayBuffer])` (or the marginally worse `new Blob([Uint8Array.from(bytes).buffer])` in Lighthouse). This is a latent bug: when `bytes` is a Node `Buffer` allocated from the shared 4KB pool — `Buffer.allocUnsafe` for small payloads — `bytes.buffer` points at the **whole pool**, not at the slice that contains the file. The resulting Blob uploads thousands of bytes of unrelated memory contents rather than the file we meant to send.

### Repro (standalone)

```js
const a = Buffer.allocUnsafe(8); a.write('AAAAAAAA')
const b = Buffer.allocUnsafe(10); b.write('BBBBBBBBBB')
a.buffer === b.buffer                 // → true (shared pool)
new Blob([a.buffer]).size             // → 8192 (the whole pool!)
await new Blob([a.buffer]).text()     // → unrelated memory contents
new Blob([a]).size                    // → 8 (correct)
```

### Why Omnipin doesn't hit this today

CARs produced by `packCAR` are always large enough (CAR header + dag-pb root + at least one block) that `fs.readFile` returns a non-pool-backed buffer, so today's behavior is correct by accident. But the pattern itself is fragile — any future change to how `bytes` is produced (streaming reads, `subarray` slicing, switching to a third-party buffer lib) would silently start corrupting uploads.

## Fix

Hand the `Uint8Array` directly to `Blob` / `File`. Same semantics, no slicing trap, shorter code.

```diff
- body: new Blob([bytes.buffer as ArrayBuffer]),
+ body: new Blob([bytes]),
```

To keep the strict DOM type checks happy (`BlobPart` requires `Uint8Array<ArrayBuffer>`, not the wider `Uint8Array<ArrayBufferLike>` that includes `SharedArrayBuffer`), narrow at the two producer boundaries:

- `UploadArgs.bytes: Uint8Array<ArrayBuffer>` in `types.ts`
- `packCAR` return type, with an explicit cast on the `readFile` result.

This removes the per-call-site `as ArrayBuffer` casts entirely.

## Files touched

- `src/providers/ipfs/lighthouse.ts`
- `src/providers/ipfs/pinata.ts`
- `src/providers/ipfs/s3.ts`
- `src/providers/ipfs/simplepage.ts`
- `src/providers/swarm/bee.ts`
- `src/providers/swarm/swarmy.ts`
- `src/types.ts`
- `src/utils/ipfs.ts`

## Verification

End-to-end tested with `bun --env-file=.env.local src/cli.ts deploy` against IPFSNinja + Lighthouse (the two providers in `.env.local`):

```
🟢 Deploying with providers: IPFSNinja, Lighthouse
📦 Packing blob-e2e (102.44KB)
🟢 Root CID: bafybeiatihow364ho6toqr3donocx4yt3ioxmer5qtog6rdikv3k2enpaq
✔ Deployed across all providers
```

Uploaded a 100KB binary asset and verified byte-identical round-trip through dweb.link:

```sh
$ curl -sL https://bafybei….ipfs.dweb.link/assets/large.bin -o /tmp/r.bin
$ md5sum /tmp/r.bin /tmp/blob-e2e/assets/large.bin
eee176faba9289dd88f388bbfc5014da  /tmp/r.bin
eee176faba9289dd88f388bbfc5014da  /tmp/blob-e2e/assets/large.bin
```

`bun run types` passes.
