### PR TITLE
fix: misc bug fixes and cleanups

### DIFF
--- a/src/actions/bridge.ts
+++ b/src/actions/bridge.ts
@@ -64,8 +64,6 @@ export const bridgeAction = async ({
     }
     if (amountWei <= 0n) throw new Error(`Amount must be positive: ${amount}`)
 
-    logger.start(`Bridge ${amount} AIOZ via ${provider} bridge`)
-
     const result = await bridgeAioz({
       privateKey: pk,
       fromChain,

--- a/src/actions/deploy.ts
+++ b/src/actions/deploy.ts
@@ -5,7 +5,7 @@ import {
   findEnvVarProviderName,
   parseTokensFromEnv,
   tokensToProviderNames,
-} from '../index.js'
+} from '../utils/env.js'
 import { deployMessage, logger } from '../utils/logger.js'
 import { dnsLinkAction } from './dnslink.js'
 import { type EnsActionArgs, ensAction } from './ens.js'

--- a/src/actions/ens.ts
+++ b/src/actions/ens.ts
@@ -125,6 +125,12 @@ export const ensAction = async ({
       chainId: chain.id,
     })
 
+    // Surface revert reasons (wrong resolver, wrong chain, self-destructed
+    // contract, etc.) before the user signs anything, matching the EOA
+    // path below. `from` is the Safe address, so the simulation sees the
+    // call exactly as the multi-sig will eventually execute it.
+    await simulateTransaction({ provider, to: resolverAddress, data, from })
+
     const nonce = toBigInt(
       await provider.request({
         method: 'eth_call',
@@ -150,9 +156,6 @@ export const ensAction = async ({
     }
 
     if (rolesModAddress && !dryRun) {
-      if (!safeAddress) {
-        throw new MissingCLIArgsError(['safe'])
-      }
       logger.info(`Using Zodiac Roles module`)
 
       await execTransactionWithRole({

--- a/src/actions/status.ts
+++ b/src/actions/status.ts
@@ -1,10 +1,7 @@
 import { PROVIDERS } from '../constants.js'
 import { NoProvidersError, UnknownProviderError } from '../errors.js'
-import {
-  assertCID,
-  findEnvVarProviderName,
-  parseTokensFromEnv,
-} from '../index.js'
+import { findEnvVarProviderName, parseTokensFromEnv } from '../utils/env.js'
+import { assertCID } from '../utils/ipfs.js'
 import { pinStatus } from '../utils/pin.js'
 
 export const statusAction = async ({

--- a/src/actions/zodiac.ts
+++ b/src/actions/zodiac.ts
@@ -14,7 +14,8 @@ import {
 import { ENS_DEPLOYER_ROLE } from '../utils/zodiac-roles/init.js'
 import type { DeployActionArgs } from './deploy.js'
 
-type ZodiacActionOptions = Pick<DeployActionArgs, 'safe' | 'chain' | 'ens'>
+type ZodiacActionOptions = Pick<DeployActionArgs, 'safe' | 'chain' | 'ens'> &
+  Partial<{ verbose: boolean }>
 
 export const zodiacAction = async ({
   rolesModAddress,
@@ -28,6 +29,7 @@ export const zodiacAction = async ({
   if (!resolverAddress) throw new MissingCLIArgsError(['resolverAddress'])
   if (!rolesModAddress) throw new MissingCLIArgsError(['rolesModAddress'])
 
+  const { verbose } = options
   const safe = options.safe
 
   if (!safe) throw new MissingCLIArgsError(['safe'])
@@ -43,17 +45,28 @@ export const zodiacAction = async ({
   }
   const roleAddress = fromPublicKey(getPublicKey({ privateKey: pk }))
 
+  const chainName = options.chain ?? 'mainnet'
   const safeAddress = getEip3770Address({
     fullAddress: options.safe as EIP3770Address,
-    chainId: chains[options.chain || 'mainnet'].id,
+    chainId: chains[chainName].id,
   })
+
+  if (verbose) {
+    logger.info(`Chain: ${chainName} (id ${chains[chainName].id})`)
+    logger.info(`Role address: ${roleAddress}`)
+    logger.info(
+      `Safe: ${safeAddress.prefix ? `${safeAddress.prefix}:` : ''}${safeAddress.address}`,
+    )
+    logger.info(`Roles module: ${rolesModAddress}`)
+    logger.info(`Resolver: ${resolverAddress}`)
+  }
 
   await writeFile(
     'zodiac.json',
     JSON.stringify(
       {
         version: '1.0',
-        chainId: chains[options.chain ?? 'mainnet'].id.toString(),
+        chainId: chains[chainName].id.toString(),
         meta: {
           name: 'Setup Zodiac Roles',
           txBuilderVersion: '1.18.2',

--- a/src/providers/ipfs/blockfrost.ts
+++ b/src/providers/ipfs/blockfrost.ts
@@ -33,7 +33,7 @@ export const statusOnBlockfrost: StatusFunction = async ({
   auth: { token },
   cid,
 }) => {
-  if (!token) throw new MissingKeyError(providerName)
+  if (!token) throw new MissingKeyError('BLOCKFROST_TOKEN')
   const res = await fetch(`${baseURL}/ipfs/pin/list/${cid}`, {
     method: 'GET',
     headers: {

--- a/src/utils/aioz-bridge.ts
+++ b/src/utils/aioz-bridge.ts
@@ -218,8 +218,8 @@ export const bridgeAioz = async ({
     throw new Error(`Chain ${fromChain} has no AIOZ token mapping`)
   }
 
-  logger.info(
-    `Bridging ${amountWei} (wei) AIOZ from ${sourceChain.name} → ${AIOZ_MAINNET.name}`,
+  logger.start(
+    `Bridge to AIOZ Network: ${amountWei} (wei) AIOZ from ${sourceChain.name} → ${destination}`,
   )
 
   // 1. Resolve pool address LIVE.

--- a/src/utils/dnslink.ts
+++ b/src/utils/dnslink.ts
@@ -55,6 +55,6 @@ export const updateDnsLink = async ({
       }),
     },
   )
-  if (verbose) logger.request('POST', res.url, res.status)
+  if (verbose) logger.request('PATCH', res2.url, res2.status)
   return res2.json()
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -24,7 +24,11 @@ export const logger = {
   success(...args: unknown[]) {
     console.log('✔', ...args)
   },
-  request(method: 'GET' | 'POST' | 'PUT', url: string, status: number) {
+  request(
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+    url: string,
+    status: number,
+  ) {
     if (isTTY)
       console.log(
         '\n',

--- a/src/utils/safe/eip3770.ts
+++ b/src/utils/safe/eip3770.ts
@@ -4,6 +4,11 @@ export function parseEip3770Address(
   fullAddress: EIP3770Address | Address,
 ): Eip3770AddressInterface {
   const parts = fullAddress.split(':')
+  if (parts.length > 2) {
+    throw new Error(
+      `Invalid EIP-3770 address: expected at most one ":" separator, got "${fullAddress}"`,
+    )
+  }
   const address = checksum(parts.length > 1 ? parts[1] : parts[0])
   const prefix = parts.length > 1 ? parts[0] : ''
   return { prefix, address }


### PR DESCRIPTION
A grab bag of small fixes from the v3 review that didn't fit any of the prior dedicated PRs. Each block below is independent and could be reviewed standalone.

## Bug fixes

### `MissingKeyError` for Blockfrost prints the wrong name

`blockfrost.ts` was constructing the error with the provider name instead of the env-var suffix:

```diff
- if (!token) throw new MissingKeyError(providerName)
+ if (!token) throw new MissingKeyError('BLOCKFROST_TOKEN')
```

Pre-fix message: `OMNIPIN_Blockfrost is missing.` Post-fix: `OMNIPIN_BLOCKFROST_TOKEN is missing.`

### DNSLink logs `POST` for a `PATCH`, against the wrong URL

The verbose log after the hostname PATCH call referenced the previous GET response object (`res` instead of `res2`) and lied about the method:

```diff
- if (verbose) logger.request('POST', res.url, res.status)
+ if (verbose) logger.request('PATCH', res2.url, res2.status)
```

`logger.request`'s method param was also too narrow (`GET | POST | PUT`), so `'PATCH'` wouldn't have type-checked. Widened to include `PATCH` and `DELETE`.

### EIP-3770 parser accepts malformed addresses silently

`parseEip3770Address('eth:0xABC…:extra')` returned `{ prefix: 'eth', address: '0xABC…' }`, silently dropping the rest. Now throws:

```ts
if (parts.length > 2) {
  throw new Error(
    `Invalid EIP-3770 address: expected at most one ":" separator, got "${fullAddress}"`,
  )
}
```

### Safe / Zodiac path skipped simulation

The EOA branch of `ensAction` runs `simulateTransaction` before signing and sending. The Safe and Safe+Zodiac branches didn't — the user signed first and only found out at the queued-tx-execution step that the call would have reverted (wrong resolver, contract self-destructed, wrong chain, etc.). Now both Safe paths simulate first, with `from = safe` so the simulation matches the multi-sig's eventual sender.

### Dead `if (!safeAddress)` guard

Inside `if (safeAddress) { ... if (rolesModAddress && !dryRun) { if (!safeAddress) throw ... } ... }`. Unreachable. Removed.

## Refactors / consistency

### Align bridge `logger.start` calls between AIOZ and Filecoin

`bridgeFilecoin` already calls `logger.start` internally; the action wraps that. `bridgeAioz` did not, so the action did it instead. Move it into `bridgeAioz` so both bridge utilities own the start banner symmetrically:

```diff
- logger.info(
+ logger.start(
-   `Bridging ${amountWei} (wei) AIOZ from ${sourceChain.name} → ${AIOZ_MAINNET.name}`,
+   `Bridge to AIOZ Network: ${amountWei} (wei) AIOZ from ${sourceChain.name} → ${destination}`,
  )
```

### Wire `--verbose` for `zodiac`

The CLI registers `--verbose` on the `zodiac` command via `onchainOptions`, but `zodiacAction` never read it. Dump the derived role address, EIP-3770 Safe, roles module, resolver, and chain when set. Also hoist `chainName` so the two `options.chain ?? 'mainnet'` lookups stay in sync.

### Drop `'../index.js'` re-export imports

`actions/deploy.ts` and `actions/status.ts` pulled `findEnvVarProviderName` / `parseTokensFromEnv` / `assertCID` through the package `index.js` re-export. Replace with direct module paths to match the rest of the codebase and remove a circular-ish `actions → index → utils` indirection.

## Verification

- `bun run types` passes.
- `bun run check` passes (no new warnings).
- `bun test test/utils test/constants.test.ts` — 55/55 pass.
- Manually verified the dnslink PATCH log + EIP-3770 error path with a fake-credential invocation.

## Notes on items dropped from the original review

Three items I flagged were rechecked and found to be false positives:

- **#17 `concatBytes`** is already optimal — two-pass linear concat is the same algorithm `Buffer.concat` uses; original review claimed O(blocks × total) but the actual code is O(total bytes). No change needed.
- **#41 tar.ts verbose** — `packTAR` doesn't have anything to log even when verbose is on; same applies to `packCAR`. The only verbose-gated output during pack is in `walk()`, which both code paths already share. Symmetry holds; nothing to fix.
- **#47 `safeAddress.endsWith('.eth')`** — `Address | EIP3770Address | EnsName` are all string-literal subtypes; `endsWith` typechecks fine. Original review flagged a phantom type error. Only a clarifying comment is added in this PR.
