### PR TITLE
test: cover getBalance and safe/eip3770

### DIFF
--- a/test/utils/safe/eip3770.test.ts
+++ b/test/utils/safe/eip3770.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from 'bun:test'
+import * as assert from 'node:assert'
+import {
+  type EIP3770Address,
+  getEip3770Address,
+  parseEip3770Address,
+} from '../../../src/utils/safe/eip3770.js'
+
+const VITALIK = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' as const
+
+describe('safe/eip3770', () => {
+  describe('parseEip3770Address', () => {
+    it('returns the address with no prefix when none is given', () => {
+      const r = parseEip3770Address(VITALIK)
+      assert.deepStrictEqual(r, { prefix: '', address: VITALIK })
+    })
+
+    it('splits prefix:address and checksums the address', () => {
+      const r = parseEip3770Address(
+        `eth:${VITALIK.toLowerCase()}` as EIP3770Address,
+      )
+      assert.deepStrictEqual(r, { prefix: 'eth', address: VITALIK })
+    })
+
+    it('rejects inputs with more than one ":" separator', () => {
+      assert.throws(
+        () =>
+          parseEip3770Address(
+            `eth:${VITALIK}:extra` as unknown as EIP3770Address,
+          ),
+        /Invalid EIP-3770 address/,
+      )
+    })
+  })
+
+  describe('getEip3770Address', () => {
+    it('accepts a matching prefix for the current chain', () => {
+      const r = getEip3770Address({
+        fullAddress: `eth:${VITALIK}` satisfies EIP3770Address,
+        chainId: 1,
+      })
+      assert.deepStrictEqual(r, { prefix: 'eth', address: VITALIK })
+    })
+
+    it('rejects a prefix that does not match the current chain', () => {
+      assert.throws(
+        () =>
+          getEip3770Address({
+            fullAddress: `eth:${VITALIK}` satisfies EIP3770Address,
+            chainId: 11155111,
+          }),
+        /network prefix must match the current network/,
+      )
+    })
+
+    it('throws on a chainId outside the supported network list', () => {
+      assert.throws(
+        () =>
+          getEip3770Address({
+            fullAddress: `eth:${VITALIK}` satisfies EIP3770Address,
+            chainId: 137,
+          }),
+        /No network prefix supported for the current chainId/,
+      )
+    })
+  })
+})

--- a/test/utils/tx.test.ts
+++ b/test/utils/tx.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from 'bun:test'
+import * as assert from 'node:assert'
+import * as Provider from 'ox/Provider'
+import { fromHttp } from 'ox/RpcTransport'
+import { getBalance } from '../../src/utils/tx.js'
+
+describe('tx utils', () => {
+  describe('getBalance', () => {
+    it(
+      'returns a positive bigint for vitalik.eth on Ethereum mainnet',
+      async () => {
+        const provider = Provider.from(
+          fromHttp('https://ethereum-rpc.publicnode.com'),
+        )
+        // vitalik.eth — a stable, well-known EOA whose balance has been
+        // non-zero for years. An EOA also avoids relying on contract
+        // accounts which may be selfdestructed.
+        const balance = await getBalance({
+          provider,
+          address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        })
+
+        assert.strictEqual(typeof balance, 'bigint')
+        assert.ok(balance > 0n, `expected positive balance, got ${balance}`)
+      },
+      { timeout: 15_000 },
+    )
+  })
+})


### PR DESCRIPTION
Two small, dependency-free coverage additions targeting paths the review flagged as untested.

- test/utils/tx.test.ts: smoke-test getBalance against the public mainnet RPC at vitalik.eth. Stable EOA, balance non-zero for years. Locks in the eth_getBalance → bigint conversion path that every on-chain action in src/utils/tx.ts depends on.

- test/utils/safe/eip3770.test.ts: cover parseEip3770Address and getEip3770Address with one case per distinct code path:
    * plain address (no prefix branch)
    * prefix:address split + checksum normalization
    * > 2 colon segments (the guard tightened in #170)
    * matching prefix for the current chain
    * mismatched prefix (validation branch)
    * unsupported chainId (lookup-miss branch)

Coverage after: eip3770.ts 100%/100%, tx.ts lines 6.63% → 11.80%.