### PR TITLE
feat(swarm): add Beeport provider and batch purchasing

### DIFF
--- a/src/actions/batch.ts
+++ b/src/actions/batch.ts
@@ -1,0 +1,138 @@
+import type { Address } from 'ox/Address'
+import type { Hex } from 'ox/Hex'
+import {
+  MissingCLIArgsError,
+  MissingKeyError,
+  UnknownProviderError,
+} from '../errors.js'
+import { logger } from '../utils/logger.js'
+import {
+  buyBatchViaBee,
+  buyBatchViaBeeport,
+  DEFAULT_BATCH_DURATION_SECONDS,
+  DEFAULT_BATCH_SIZE_BYTES,
+  parseDuration,
+  parseSize,
+} from '../utils/swarm-batch.js'
+
+export type BatchActionArgs = Partial<{
+  provider: string
+  size: string
+  duration: string
+  'node-address': Address
+  'rpc-url': string
+  slippage: string
+  verbose: boolean
+}>
+
+const SUPPORTED_PROVIDERS = new Set(['Beeport', 'Bee'])
+
+/**
+ * Purchase an immutable Swarm postage batch.
+ *
+ * `--provider=Beeport`: pays native xDAI via Beeport's SushiSwap router. Signs
+ *  with `OMNIPIN_BEEPORT_TOKEN` (the same key used to authenticate uploads).
+ *
+ * `--provider=Bee`:    pays pre-held BZZ via the canonical PostageStamp.
+ *  Signs with `OMNIPIN_PK`.
+ */
+export const batchAction = async ({
+  options = {},
+}: {
+  options: BatchActionArgs
+}) => {
+  const provider = options.provider
+  if (!provider) throw new MissingCLIArgsError(['provider'])
+  if (!SUPPORTED_PROVIDERS.has(provider))
+    throw new UnknownProviderError(provider)
+
+  const sizeBytes = options.size
+    ? parseSize(options.size)
+    : DEFAULT_BATCH_SIZE_BYTES
+  const durationSeconds = options.duration
+    ? parseDuration(options.duration)
+    : DEFAULT_BATCH_DURATION_SECONDS
+
+  logger.start(
+    `Buying Swarm batch via ${provider} (size=${sizeBytes}B, duration=${durationSeconds}s)`,
+  )
+
+  if (provider === 'Beeport') {
+    const privateKey = process.env.OMNIPIN_BEEPORT_TOKEN as Hex | undefined
+    if (!privateKey) throw new MissingKeyError('BEEPORT_TOKEN')
+
+    const slippage =
+      options.slippage !== undefined
+        ? Number.parseFloat(options.slippage)
+        : undefined
+    if (
+      slippage !== undefined &&
+      (!Number.isFinite(slippage) || slippage < 0 || slippage > 1)
+    ) {
+      throw new Error(
+        `--slippage must be a number in [0, 1] (fraction), got: ${options.slippage}`,
+      )
+    }
+
+    const result = await buyBatchViaBeeport({
+      privateKey,
+      sizeBytes,
+      durationSeconds,
+      nodeAddress: options['node-address'],
+      slippage,
+      rpcUrl: options['rpc-url'],
+      verbose: options.verbose,
+    })
+
+    logger.success(`Batch ID: ${result.batchId}`)
+    if (options.verbose) {
+      logger.text(
+        JSON.stringify(
+          {
+            batchId: result.batchId,
+            txHash: result.txHash,
+            depth: result.depth,
+            bucketDepth: result.bucketDepth,
+            initialBalancePerChunk: result.initialBalancePerChunk.toString(),
+            totalBzzAmount: result.totalBzzAmount.toString(),
+          },
+          null,
+          2,
+        ),
+      )
+    }
+    return
+  }
+
+  if (provider === 'Bee') {
+    const privateKey = process.env.OMNIPIN_PK as Hex | undefined
+    if (!privateKey) throw new MissingKeyError('PK')
+
+    const result = await buyBatchViaBee({
+      privateKey,
+      sizeBytes,
+      durationSeconds,
+      nodeAddress: options['node-address'],
+      rpcUrl: options['rpc-url'],
+      verbose: options.verbose,
+    })
+
+    logger.success(`Batch ID: ${result.batchId}`)
+    if (options.verbose) {
+      logger.text(
+        JSON.stringify(
+          {
+            batchId: result.batchId,
+            txHash: result.txHash,
+            depth: result.depth,
+            bucketDepth: result.bucketDepth,
+            initialBalancePerChunk: result.initialBalancePerChunk.toString(),
+            totalBzzAmount: result.totalBzzAmount.toString(),
+          },
+          null,
+          2,
+        ),
+      )
+    }
+  }
+}

--- a/src/actions/deploy.ts
+++ b/src/actions/deploy.ts
@@ -121,9 +121,10 @@ export const deployAction = async ({
           bytes,
           token: apiTokens.get(envVar)!,
           verbose,
-          name: '',
+          name: 'omnipin-deploy',
           first: true,
           beeURL: apiTokens.get('BEE_URL'),
+          beeportURL: apiTokens.get('BEEPORT_URL'),
         })
         swarmCid = result.cid
         cid = result.rID!

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 import type { Address } from 'ox/Address'
 import { CLI } from 'spektr'
 import { colorPlugin } from 'spektr/plugins/color.js'
+import { type BatchActionArgs, batchAction } from './actions/batch.js'
 import { type BridgeActionArgs, bridgeAction } from './actions/bridge.js'
 import { type DeployActionArgs, deployAction } from './actions/deploy.js'
 import { type DepositActionArgs, depositAction } from './actions/deposit.js'
@@ -340,6 +341,60 @@ cli.command<[string]>(
         name: 'from',
         description:
           'Wallet address holding the tokens. Defaults to the signer address.',
+        type: 'string',
+      },
+      {
+        name: 'verbose',
+        description: 'More verbose logs',
+        type: 'boolean',
+        short: 'v',
+      },
+    ] as const,
+  },
+)
+
+cli.command<[]>(
+  'batch',
+  (_positionals, options) =>
+    batchAction({
+      options: options as BatchActionArgs,
+    }),
+  {
+    description:
+      'Purchase an immutable Swarm postage batch (Beeport: native xDAI swap; Bee: BZZ via canonical PostageStamp).',
+    options: [
+      {
+        name: 'provider',
+        description: 'Provider to purchase the batch through (Beeport or Bee)',
+        type: 'string',
+      },
+      {
+        name: 'size',
+        description:
+          'Storage capacity for the batch (e.g. 110MB, 1GB). Drives the postage-stamp depth. Default 110MB.',
+        type: 'string',
+      },
+      {
+        name: 'duration',
+        description:
+          'How long the batch must remain valid (e.g. 30d, 12h). Default 30d.',
+        type: 'string',
+      },
+      {
+        name: 'node-address',
+        description:
+          'Bee node address recorded with the batch. Defaults to the signer.',
+        type: 'string',
+      },
+      {
+        name: 'rpc-url',
+        description: 'Custom Gnosis RPC URL',
+        type: 'string',
+      },
+      {
+        name: 'slippage',
+        description:
+          'Slippage fraction for the Beeport swap (0–1). Default 0.2 (20%).',
         type: 'string',
       },
       {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,7 @@ import { pinOnQuicknode } from './providers/ipfs/quicknode.js'
 import { uploadToSimplePage } from './providers/ipfs/simplepage.js'
 import { specPin, specStatus, specUnpin } from './providers/ipfs/spec.js'
 import { uploadOnBee } from './providers/swarm/bee.js'
+import { uploadOnBeeport } from './providers/swarm/beeport.js'
 import { uploadOnSwarmy } from './providers/swarm/swarmy.js'
 import type {
   StatusFunction,
@@ -132,6 +133,12 @@ export const PROVIDERS: Record<
   BEE_TOKEN: {
     name: 'Bee',
     upload: uploadOnBee,
+    supported: 'upload',
+    protocol: 'swarm',
+  },
+  BEEPORT_TOKEN: {
+    name: 'Beeport',
+    upload: uploadOnBeeport,
     supported: 'upload',
     protocol: 'swarm',
   },

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,4 @@
-export { randomInt } from 'node:crypto'
+export { randomBytes, randomInt } from 'node:crypto'
 export { setTimeout } from 'node:timers/promises'
 export { styleText } from 'node:util'
 

--- a/src/providers/swarm/beeport.ts
+++ b/src/providers/swarm/beeport.ts
@@ -1,0 +1,169 @@
+import type { Address } from 'ox/Address'
+import { fromPublicKey } from 'ox/Address'
+import { fromString } from 'ox/Bytes'
+import type { Hex } from 'ox/Hex'
+import { getSignPayload } from 'ox/PersonalMessage'
+import * as Provider from 'ox/Provider'
+import { fromHttp } from 'ox/RpcTransport'
+import { getPublicKey, sign } from 'ox/Secp256k1'
+import * as Signature from 'ox/Signature'
+import {
+  DeployError,
+  MissingKeyError,
+  PinningNotSupportedError,
+} from '../../errors.js'
+import type { UploadFunction } from '../../types.js'
+import { logger } from '../../utils/logger.js'
+import { referenceToCIDString } from '../../utils/swarm.js'
+import { findUsableBatch, GNOSIS } from '../../utils/swarm-batch.js'
+
+const providerName = 'Beeport'
+
+const DEFAULT_BEEPORT_URL = 'https://beeport.ethswarm.org'
+
+/**
+ * In-memory cache of `signerAddress → batchId`. Skips the on-chain registry
+ * + Bee-node lookup on subsequent uploads within the same process.
+ */
+const batchCache = new Map<string, Hex>()
+
+/**
+ * EIP-191 personal_sign over a UTF-8 string. Beeport's backend verifies
+ * uploads with `viem.verifyMessage`, which uses the standard
+ * `\x19Ethereum Signed Message:\n<len>` prefix.
+ */
+const personalSign = ({
+  message,
+  privateKey,
+}: {
+  message: string
+  privateKey: Hex
+}): Hex => {
+  const payload = getSignPayload(fromString(message))
+  return Signature.toHex(sign({ privateKey, payload }))
+}
+
+const resolveBatchId = async ({
+  signer,
+  sizeBytes,
+  beeportURL,
+  verbose,
+}: {
+  signer: Address
+  sizeBytes: bigint
+  beeportURL: string
+  verbose?: boolean
+}): Promise<Hex> => {
+  // 1. Caller-provided override via env var.
+  const envBatchId = process.env.OMNIPIN_BEEPORT_BATCH_ID
+  if (envBatchId) {
+    return (envBatchId.startsWith('0x') ? envBatchId : `0x${envBatchId}`) as Hex
+  }
+
+  // 2. In-memory cache from a previous upload in the same process.
+  const cached = batchCache.get(signer)
+  if (cached) return cached
+
+  // 3. Reuse an already-purchased on-chain batch (registered via Beeport),
+  // confirmed usable by the Bee node we are about to upload through.
+  const rpcUrl = process.env.OMNIPIN_GNOSIS_RPC_URL ?? GNOSIS.rpc
+  const provider = Provider.from(fromHttp(rpcUrl))
+  const existing = await findUsableBatch({
+    provider,
+    account: signer,
+    sizeBytes,
+    beeURL: beeportURL,
+  })
+  if (existing) {
+    if (verbose) {
+      logger.info(
+        `Reusing existing Beeport batch ${existing.batchId} (depth=${existing.depth}, remainingBalance=${existing.remainingBalance})`,
+      )
+    }
+    batchCache.set(signer, existing.batchId)
+    return existing.batchId
+  }
+
+  // Auto-purchase is intentionally not supported here: a freshly created
+  // postage batch is not usable on the Bee node for several minutes (the
+  // node's stamps indexer lags chain), which would make `omnipin deploy`
+  // fail with "batch with id not found" on the very first upload. Users
+  // must buy a batch ahead of time with `omnipin batch --provider=Beeport`
+  // and either pass it via `OMNIPIN_BEEPORT_BATCH_ID` or let omnipin pick
+  // it up from the StampsRegistry once the Bee node has indexed it.
+  throw new MissingKeyError('BEEPORT_BATCH_ID')
+}
+
+export const uploadOnBeeport: UploadFunction<{ beeportURL?: string }> = async ({
+  bytes,
+  name,
+  size,
+  verbose,
+  first,
+  beeportURL,
+}) => {
+  if (!first) throw new PinningNotSupportedError(providerName)
+
+  // The provider signs uploads with its own dedicated key. `OMNIPIN_PK` is
+  // reserved for ENS / Safe writes and must NOT be reused here.
+  const privateKey = process.env.OMNIPIN_BEEPORT_TOKEN as Hex | undefined
+  if (!privateKey) throw new MissingKeyError('BEEPORT_TOKEN')
+
+  const url =
+    beeportURL ?? process.env.OMNIPIN_BEEPORT_URL ?? DEFAULT_BEEPORT_URL
+
+  const signer = fromPublicKey(getPublicKey({ privateKey }))
+  // Prefer the actual upload size when picking a batch. Falls back to the
+  // byte length of the encoded body for unit tests where `size` may not
+  // match `bytes.byteLength`.
+  const sizeBytes = BigInt(size > 0 ? size : bytes.byteLength)
+  const batchId = await resolveBatchId({
+    signer,
+    sizeBytes,
+    beeportURL: url,
+    verbose,
+  })
+
+  // Beeport's backend defaults `messageContent` to `${fileName}:${batchId}`
+  // when the header is omitted, but signing the exact string we send is more
+  // explicit and avoids any header-normalisation surprises.
+  const fileName = name || 'upload'
+  const messageContent = `${fileName}:${batchId}`
+  const signedMessage = personalSign({
+    message: messageContent,
+    privateKey,
+  })
+
+  const res = await fetch(`${url}/bzz`, {
+    body: new Blob([bytes]),
+    headers: {
+      'Content-Type': 'application/x-tar',
+      'Swarm-Postage-Batch-Id': batchId.replace(/^0x/, ''),
+      'Swarm-Index-Document': 'index.html',
+      'Swarm-Error-Document': 'index.html',
+      'Swarm-Collection': 'true',
+      'x-upload-signed-message': signedMessage,
+      'x-uploader-address': signer,
+      'x-file-name': fileName,
+      'x-message-content': messageContent,
+    },
+    method: 'POST',
+  })
+
+  if (verbose) logger.request('POST', res.url, res.status)
+
+  const json = (await res.json()) as { reference?: string; message?: string }
+
+  if (!res.ok) {
+    throw new DeployError(providerName, json.message ?? `HTTP ${res.status}`)
+  }
+
+  if (!json.reference) {
+    throw new DeployError(providerName, 'Missing reference in response')
+  }
+
+  return {
+    cid: referenceToCIDString(`0x${json.reference}`),
+    rID: json.reference,
+  }
+}

--- a/src/utils/swarm-batch.ts
+++ b/src/utils/swarm-batch.ts
@@ -1,0 +1,788 @@
+import { from as eventFrom, getSelector as getEventSelector } from 'ox/AbiEvent'
+import { decodeResult, encodeData } from 'ox/AbiFunction'
+import type { Address } from 'ox/Address'
+import { fromPublicKey } from 'ox/Address'
+import { type Hex, toBigInt } from 'ox/Hex'
+import * as Provider from 'ox/Provider'
+import { fromHttp } from 'ox/RpcTransport'
+import { getPublicKey } from 'ox/Secp256k1'
+import { randomBytes } from '../deps.js'
+import { logger } from './logger.js'
+import { sendTransaction, waitForTransaction } from './tx.js'
+
+// ─── Chain ────────────────────────────────────────────────────────────────────
+
+export const GNOSIS = {
+  id: 100,
+  name: 'Gnosis',
+  rpc: 'https://rpc.gnosischain.com',
+  explorer: 'https://gnosisscan.io',
+}
+
+/** Block time on Gnosis chain (seconds). Used for postage-stamp amount math. */
+const GNOSIS_BLOCK_TIME = 5n
+
+// ─── Contracts ────────────────────────────────────────────────────────────────
+
+/** BZZ ERC-20 on Gnosis. */
+export const BZZ_TOKEN: Address = '0xdBF3Ea6F5beE45c02255B2c26a16F300502F68da'
+
+/** Wrapped xDAI on Gnosis (used as the final hop in Beeport's exact-output path). */
+export const WXDAI: Address = '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d'
+
+/**
+ * Beeport's SushiSwapStampsRouter on Gnosis. Wraps the canonical PostageStamp
+ * and lets callers swap any token (or native xDAI) → BZZ in one tx.
+ */
+export const BEEPORT_REGISTRY: Address =
+  '0xf244cC25EAD03a99de8B407A3237aaf54D1b779C'
+
+/**
+ * StampsRegistry wrapper that Beeport's router delegates to. Routes
+ * `createBatchRegistry` calls into the canonical PostageStamp.
+ */
+export const STAMPS_REGISTRY: Address =
+  '0x5EBfBeFB1E88391eFb022d5d33302f50a46bF4f3'
+
+/** Canonical Swarm PostageStamp on Gnosis (price oracle + batch ledger). */
+export const POSTAGE_STAMP: Address =
+  '0x45a1502382541Cd610CC9068e88727426b696293'
+
+// ─── ABIs ─────────────────────────────────────────────────────────────────────
+
+const lastPriceAbi = {
+  name: 'lastPrice',
+  type: 'function',
+  stateMutability: 'view',
+  inputs: [],
+  outputs: [{ type: 'uint64' }],
+} as const
+
+const minInitialBalancePerChunkAbi = {
+  name: 'minimumInitialBalancePerChunk',
+  type: 'function',
+  stateMutability: 'view',
+  inputs: [],
+  outputs: [{ type: 'uint256' }],
+} as const
+
+const erc20BalanceOfAbi = {
+  name: 'balanceOf',
+  type: 'function',
+  stateMutability: 'view',
+  inputs: [{ name: 'account', type: 'address' }],
+  outputs: [{ type: 'uint256' }],
+} as const
+
+const erc20ApproveAbi = {
+  name: 'approve',
+  type: 'function',
+  stateMutability: 'nonpayable',
+  inputs: [
+    { name: 'spender', type: 'address' },
+    { name: 'amount', type: 'uint256' },
+  ],
+  outputs: [{ type: 'bool' }],
+} as const
+
+/**
+ * `getOwnerBatches(address)` on the StampsRegistry. Returns every batch the
+ * given address has paid for via the registry (i.e. via Beeport's router).
+ */
+const getOwnerBatchesAbi = {
+  name: 'getOwnerBatches',
+  type: 'function',
+  stateMutability: 'view',
+  inputs: [{ name: '_owner', type: 'address' }],
+  outputs: [
+    {
+      type: 'tuple[]',
+      components: [
+        { name: 'batchId', type: 'bytes32' },
+        { name: 'totalAmount', type: 'uint256' },
+        { name: 'normalisedBalance', type: 'uint256' },
+        { name: 'nodeAddress', type: 'address' },
+        { name: 'payer', type: 'address' },
+        { name: 'depth', type: 'uint8' },
+        { name: 'bucketDepth', type: 'uint8' },
+        { name: 'immutable_', type: 'bool' },
+        { name: 'timestamp', type: 'uint256' },
+      ],
+    },
+  ],
+} as const
+
+/** `remainingBalance(bytes32)` on the canonical PostageStamp. */
+const remainingBalanceAbi = {
+  name: 'remainingBalance',
+  type: 'function',
+  stateMutability: 'view',
+  inputs: [{ name: '_batchId', type: 'bytes32' }],
+  outputs: [{ type: 'uint256' }],
+} as const
+
+/**
+ * `quoteSingleHop(address,uint24,uint256)` on Beeport's router. State-changing
+ * by signature (the underlying Quoter mutates), but designed to be called via
+ * `eth_call` for free off-chain estimation.
+ */
+const quoteSingleHopAbi = {
+  name: 'quoteSingleHop',
+  type: 'function',
+  stateMutability: 'nonpayable',
+  inputs: [
+    { name: 'tokenIn', type: 'address' },
+    { name: 'fee', type: 'uint24' },
+    { name: 'bzzAmountOut', type: 'uint256' },
+  ],
+  outputs: [{ name: 'amountIn', type: 'uint256' }],
+} as const
+
+/** `createBatch(address,uint256,uint8,uint8,bytes32,bool)` on the canonical PostageStamp. */
+const createBatchAbi = {
+  name: 'createBatch',
+  type: 'function',
+  stateMutability: 'nonpayable',
+  inputs: [
+    { name: '_owner', type: 'address' },
+    { name: '_initialBalancePerChunk', type: 'uint256' },
+    { name: '_depth', type: 'uint8' },
+    { name: '_bucketDepth', type: 'uint8' },
+    { name: '_nonce', type: 'bytes32' },
+    { name: '_immutable', type: 'bool' },
+  ],
+  outputs: [],
+} as const
+
+/** `createBatchNative(bytes,uint256,uint256,(...))` on Beeport's router. */
+const createBatchNativeAbi = {
+  name: 'createBatchNative',
+  type: 'function',
+  stateMutability: 'payable',
+  inputs: [
+    { name: 'path', type: 'bytes' },
+    { name: 'maxAmountIn', type: 'uint256' },
+    { name: 'bzzAmountOut', type: 'uint256' },
+    {
+      name: 'p',
+      type: 'tuple',
+      components: [
+        { name: 'owner', type: 'address' },
+        { name: 'nodeAddress', type: 'address' },
+        { name: 'initialBalancePerChunk', type: 'uint256' },
+        { name: 'depth', type: 'uint8' },
+        { name: 'bucketDepth', type: 'uint8' },
+        { name: 'nonce', type: 'bytes32' },
+        { name: 'immutable_', type: 'bool' },
+      ],
+    },
+  ],
+  outputs: [],
+} as const
+
+/** Event emitted by Beeport's router on successful batch creation. */
+const batchCreatedViaSwapEvent = eventFrom(
+  'event BatchCreatedViaSwap(bytes32 indexed batchId, address indexed owner, address tokenIn, uint256 amountIn, uint256 bzzAmount)',
+)
+const BATCH_CREATED_VIA_SWAP_TOPIC = getEventSelector(batchCreatedViaSwapEvent)
+
+/** Event emitted by the canonical PostageStamp on `createBatch`. */
+const batchCreatedEvent = eventFrom(
+  'event BatchCreated(bytes32 indexed batchId, uint256 totalAmount, uint256 normalisedBalance, address owner, uint8 depth, uint8 bucketDepth, bool immutableFlag)',
+)
+const BATCH_CREATED_TOPIC = getEventSelector(batchCreatedEvent)
+
+// ─── Sizing helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Effective storage size in bytes for a given depth, assuming `ENCRYPTION_OFF`
+ * and `REDUNDANCY_OFF` (matches what omnipin uploads as static websites).
+ *
+ * Derived from `bee-js`'s capacity breakpoints table.
+ */
+const EFFECTIVE_SIZE_BREAKPOINTS_BYTES: ReadonlyArray<
+  [depth: number, bytes: bigint]
+> = [
+  [17, 44_700n],
+  [18, 6_660_000n],
+  [19, 112_060_000n],
+  [20, 687_620_000n],
+  [21, 3_220_000_000n],
+  [22, 13_730_000_000n],
+  [23, 56_010_000_000n],
+  [24, 224_730_000_000n],
+  [25, 896_550_000_000n],
+  [26, 3_582_320_000_000n],
+  [27, 14_322_320_000_000n],
+  [28, 57_278_140_000_000n],
+  [29, 229_098_280_000_000n],
+  [30, 916_366_220_000_000n],
+  [31, 3_665_437_700_000_000n],
+  [32, 14_661_727_950_000_000n],
+  [33, 58_646_846_650_000_000n],
+  [34, 234_587_280_180_000_000n],
+]
+
+/**
+ * Smallest postage-stamp depth whose effective volume covers the requested
+ * number of bytes. Falls back to the maximum depth if nothing fits.
+ */
+export const getDepthForSize = (sizeBytes: bigint): number => {
+  for (const [depth, capacity] of EFFECTIVE_SIZE_BREAKPOINTS_BYTES) {
+    if (capacity >= sizeBytes) return depth
+  }
+  // The table is non-empty (declared as a const literal), so `at(-1)` is
+  // guaranteed to return a value here.
+  const last = EFFECTIVE_SIZE_BREAKPOINTS_BYTES.at(-1)
+  if (!last) throw new Error('Empty depth table')
+  return last[0]
+}
+
+/** Bucket depth for postage stamps. Standard value. */
+export const DEFAULT_BUCKET_DEPTH = 16
+
+/** Default storage capacity used by the deploy flow's auto-batch-purchase. */
+export const DEFAULT_BATCH_SIZE_BYTES = 110n * 1024n * 1024n // 110 MB
+
+/** Default batch duration used by the deploy flow's auto-batch-purchase. */
+export const DEFAULT_BATCH_DURATION_SECONDS = 30n * 24n * 60n * 60n // 30 days
+
+// ─── Size / duration parsing ─────────────────────────────────────────────────
+
+/** Parse e.g. `"110MB"`, `"1.5GB"`, `"512KiB"`, or a plain byte count. */
+export const parseSize = (input: string): bigint => {
+  const m = input
+    .trim()
+    .match(/^(\d+(?:\.\d+)?)\s*(B|KB|KIB|MB|MIB|GB|GIB|TB|TIB)?$/i)
+  if (!m || m[1] === undefined) throw new Error(`Invalid size: ${input}`)
+  const n = Number.parseFloat(m[1])
+  const unit = (m[2] ?? 'B').toUpperCase()
+  const mult: Record<string, bigint> = {
+    B: 1n,
+    KB: 1000n,
+    KIB: 1024n,
+    MB: 1000n * 1000n,
+    MIB: 1024n * 1024n,
+    GB: 1000n * 1000n * 1000n,
+    GIB: 1024n * 1024n * 1024n,
+    TB: 1000n ** 4n,
+    TIB: 1024n ** 4n,
+  }
+  // Convert via Number → BigInt; safe for sizes up to ~Number.MAX_SAFE_INTEGER
+  // bytes (≈9 PB), more than enough for any postage stamp use case.
+  return BigInt(Math.floor(n * Number(mult[unit] ?? 1n)))
+}
+
+/** Parse e.g. `"30d"`, `"24h"`, `"3600s"`, `"2w"`, or a plain second count. */
+export const parseDuration = (input: string): bigint => {
+  const m = input.trim().match(/^(\d+(?:\.\d+)?)\s*(s|m|h|d|w)?$/i)
+  if (!m || m[1] === undefined) throw new Error(`Invalid duration: ${input}`)
+  const n = Number.parseFloat(m[1])
+  const unit = (m[2] ?? 's').toLowerCase()
+  const mult: Record<string, bigint> = {
+    s: 1n,
+    m: 60n,
+    h: 3600n,
+    d: 86_400n,
+    w: 604_800n,
+  }
+  return BigInt(Math.floor(n * Number(mult[unit] ?? 1n)))
+}
+
+// ─── On-chain reads ───────────────────────────────────────────────────────────
+
+const callUint = async ({
+  provider,
+  to,
+  data,
+}: {
+  provider: Provider.Provider
+  to: Address
+  data: Hex
+}): Promise<bigint> => {
+  const res = (await provider.request({
+    method: 'eth_call',
+    params: [{ to, data }, 'latest'],
+  })) as Hex
+  return toBigInt(res)
+}
+
+/** Current per-chunk-per-block price (PLUR). */
+export const getLastPrice = (provider: Provider.Provider): Promise<bigint> =>
+  callUint({
+    provider,
+    to: POSTAGE_STAMP,
+    data: encodeData(lastPriceAbi),
+  })
+
+/** Per-chunk amount needed to make a brand-new batch valid. */
+export const getMinimumInitialBalancePerChunk = (
+  provider: Provider.Provider,
+): Promise<bigint> =>
+  callUint({
+    provider,
+    to: POSTAGE_STAMP,
+    data: encodeData(minInitialBalancePerChunkAbi),
+  })
+
+/** BZZ balance of an account. */
+export const getBzzBalance = ({
+  provider,
+  account,
+}: {
+  provider: Provider.Provider
+  account: Address
+}): Promise<bigint> =>
+  callUint({
+    provider,
+    to: BZZ_TOKEN,
+    data: encodeData(erc20BalanceOfAbi, [account]),
+  })
+
+/**
+ * Amount per chunk required to cover `durationSeconds` at the current
+ * `lastPrice`, including the +1 PLUR safety margin that the canonical
+ * contract requires above `minimumInitialBalancePerChunk`.
+ */
+export const getAmountForDuration = async ({
+  provider,
+  durationSeconds,
+}: {
+  provider: Provider.Provider
+  durationSeconds: bigint
+}): Promise<bigint> => {
+  const lastPrice = await getLastPrice(provider)
+  const blocks = durationSeconds / GNOSIS_BLOCK_TIME
+  const minimum = await getMinimumInitialBalancePerChunk(provider)
+  const computed = blocks * lastPrice + 1n
+  return computed > minimum ? computed : minimum
+}
+
+/**
+ * Single batch entry returned by `StampsRegistry.getOwnerBatches`.
+ */
+export type OwnedBatch = {
+  batchId: Hex
+  totalAmount: bigint
+  normalisedBalance: bigint
+  nodeAddress: Address
+  payer: Address
+  depth: number
+  bucketDepth: number
+  immutable: boolean
+  timestamp: bigint
+  /** Live remaining per-chunk balance, fetched separately. */
+  remainingBalance: bigint
+}
+
+/**
+ * List every batch the given address has paid for via the StampsRegistry,
+ * along with each batch's live `remainingBalance`. Batches with zero balance
+ * have expired and cannot be used to upload.
+ */
+export const getOwnedBatches = async ({
+  provider,
+  account,
+}: {
+  provider: Provider.Provider
+  account: Address
+}): Promise<OwnedBatch[]> => {
+  const raw = await provider.request({
+    method: 'eth_call',
+    params: [
+      {
+        to: STAMPS_REGISTRY,
+        data: encodeData(getOwnerBatchesAbi, [account]),
+      },
+      'latest',
+    ],
+  })
+  const entries = decodeResult(getOwnerBatchesAbi, raw)
+  if (entries.length === 0) return []
+
+  const remaining = await Promise.all(
+    entries.map((e) =>
+      callUint({
+        provider,
+        to: POSTAGE_STAMP,
+        data: encodeData(remainingBalanceAbi, [e.batchId]),
+      }).catch(() => 0n),
+    ),
+  )
+
+  return entries.map((e, i) => ({
+    batchId: e.batchId,
+    totalAmount: e.totalAmount,
+    normalisedBalance: e.normalisedBalance,
+    nodeAddress: e.nodeAddress,
+    payer: e.payer,
+    depth: e.depth,
+    bucketDepth: e.bucketDepth,
+    immutable: e.immutable_,
+    timestamp: e.timestamp,
+    remainingBalance: remaining[i] ?? 0n,
+  }))
+}
+
+/**
+ * Ask the Bee node whether a batch is ready to accept uploads.
+ *
+ * A batch can exist on-chain (and in the StampsRegistry) without the Bee node
+ * having indexed it yet, or it may correspond to a failed Beeport swap where
+ * the registry recorded the entry but the canonical PostageStamp never
+ * finalised it. `/stamps/<id>` returning `usable: true` is the authoritative
+ * signal that uploads will succeed.
+ */
+const isBatchUsableOnBee = async ({
+  beeURL,
+  batchId,
+}: {
+  beeURL: string
+  batchId: Hex
+}): Promise<boolean> => {
+  try {
+    const res = await fetch(
+      `${beeURL.replace(/\/$/, '')}/stamps/${batchId.replace(/^0x/, '')}`,
+    )
+    if (!res.ok) return false
+    const json = (await res.json()) as { usable?: boolean }
+    return json.usable === true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Find the best already-purchased batch usable for an upload of `sizeBytes`.
+ *
+ * "Usable" means: still has live remaining balance, was sized for at least
+ * `sizeBytes`, and — if `beeURL` is provided — the Bee node confirms the
+ * batch is `usable`.
+ *
+ * When multiple batches qualify, the one with the largest `remainingBalance`
+ * wins — that minimises the chance of falling back into an auto-purchase
+ * before the next upload.
+ *
+ * Returns `null` when nothing usable exists. Callers can then auto-purchase.
+ */
+export const findUsableBatch = async ({
+  provider,
+  account,
+  sizeBytes,
+  beeURL,
+}: {
+  provider: Provider.Provider
+  account: Address
+  sizeBytes: bigint
+  beeURL?: string
+}): Promise<OwnedBatch | null> => {
+  const requiredDepth = getDepthForSize(sizeBytes)
+  const batches = await getOwnedBatches({ provider, account })
+  const onChainCandidates = batches
+    .filter((b) => b.remainingBalance > 0n && b.depth >= requiredDepth)
+    // Prefer the batch with the most remaining runway.
+    .sort((a, b) => (b.remainingBalance > a.remainingBalance ? 1 : -1))
+
+  if (!beeURL) return onChainCandidates[0] ?? null
+
+  // Verify each candidate against the Bee node before picking one. Some
+  // registry entries do not correspond to a finalised on-chain batch and the
+  // node will reject uploads against them.
+  for (const candidate of onChainCandidates) {
+    if (await isBatchUsableOnBee({ beeURL, batchId: candidate.batchId })) {
+      return candidate
+    }
+  }
+  return null
+}
+
+// ─── Path encoding (SushiSwap V3, exact-output) ──────────────────────────────
+
+const hexToBytes = (h: string): Uint8Array => {
+  const stripped = h.startsWith('0x') ? h.slice(2) : h
+  const out = new Uint8Array(stripped.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(stripped.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
+}
+
+const bytesToHex = (b: Uint8Array): Hex => {
+  let s = '0x'
+  for (const byte of b) s += byte.toString(16).padStart(2, '0')
+  return s as Hex
+}
+
+/**
+ * Encode a single-hop exact-output path: `BZZ ++ uint24(fee) ++ tokenIn`.
+ *
+ * The router's `createBatchNative` requires the path to end in WXDAI (the
+ * router wraps native xDAI before swapping).
+ */
+const encodeSingleHopPath = ({
+  fee,
+  tokenIn,
+}: {
+  fee: number
+  tokenIn: Address
+}): Hex => {
+  const out = new Uint8Array(20 + 3 + 20)
+  // tokenOut = BZZ (first 20 bytes)
+  out.set(hexToBytes(BZZ_TOKEN), 0)
+  // fee (3 bytes, big-endian uint24)
+  out[20] = (fee >>> 16) & 0xff
+  out[21] = (fee >>> 8) & 0xff
+  out[22] = fee & 0xff
+  // tokenIn (next 20 bytes)
+  out.set(hexToBytes(tokenIn), 23)
+  return bytesToHex(out)
+}
+
+// ─── Receipt log helpers ──────────────────────────────────────────────────────
+
+type RpcLog = {
+  address: Address
+  data: Hex
+  topics: readonly Hex[]
+}
+
+const extractBatchIdFromReceipt = (
+  logs: readonly RpcLog[],
+  topic0: Hex,
+  emitter: Address,
+): Hex => {
+  for (const log of logs) {
+    if (
+      log.address.toLowerCase() !== emitter.toLowerCase() ||
+      log.topics[0]?.toLowerCase() !== topic0.toLowerCase()
+    ) {
+      continue
+    }
+    // `batchId` is the first indexed param → topics[1]
+    const batchId = log.topics[1]
+    if (batchId) return batchId
+  }
+  throw new Error(
+    `Batch creation event not found in receipt (emitter=${emitter}, topic0=${topic0})`,
+  )
+}
+
+// ─── Public entry points ──────────────────────────────────────────────────────
+
+export type BuyBatchOptions = {
+  privateKey: Hex
+  sizeBytes?: bigint
+  durationSeconds?: bigint
+  /**
+   * Bee node address. If omitted, defaults to the signer address — fine for
+   * Beeport's hosted uploader, which signs its own uploads, but bee operators
+   * must pass their node's overlay address explicitly.
+   */
+  nodeAddress?: Address
+  /**
+   * Slippage cap as a fraction (e.g. `0.10` = 10 % above `bzzAmountOut`).
+   * Applied only on the Beeport path, where we must commit to a `maxAmountIn`
+   * up front. Defaults to `0.20` (20 %).
+   */
+  slippage?: number
+  rpcUrl?: string
+  verbose?: boolean
+}
+
+export type BuyBatchResult = {
+  batchId: Hex
+  txHash: Hex
+  depth: number
+  bucketDepth: number
+  initialBalancePerChunk: bigint
+  totalBzzAmount: bigint
+}
+
+/**
+ * Purchase an immutable Swarm postage batch via Beeport's SushiSwap router,
+ * paying with native xDAI. Returns the resulting batch ID.
+ */
+export const buyBatchViaBeeport = async (
+  opts: BuyBatchOptions,
+): Promise<BuyBatchResult> => {
+  const provider = Provider.from(fromHttp(opts.rpcUrl ?? GNOSIS.rpc))
+
+  const signer = fromPublicKey(getPublicKey({ privateKey: opts.privateKey }))
+  const sizeBytes = opts.sizeBytes ?? DEFAULT_BATCH_SIZE_BYTES
+  const durationSeconds = opts.durationSeconds ?? DEFAULT_BATCH_DURATION_SECONDS
+  const slippage = opts.slippage ?? 0.2
+
+  const depth = getDepthForSize(sizeBytes)
+  const bucketDepth = DEFAULT_BUCKET_DEPTH
+  const initialBalancePerChunk = await getAmountForDuration({
+    provider,
+    durationSeconds,
+  })
+  // bzzAmountOut = initialBalancePerChunk × 2^depth
+  const bzzAmountOut = initialBalancePerChunk * (1n << BigInt(depth))
+
+  // Path = BZZ ++ fee(3000) ++ WXDAI (single 0.3 % hop, exact-output).
+  const poolFee = 3000
+  const path = encodeSingleHopPath({ fee: poolFee, tokenIn: WXDAI })
+
+  // Quote the exact-output swap via the router (free off-chain estimation).
+  const quotedAmountIn = await callUint({
+    provider,
+    to: BEEPORT_REGISTRY,
+    data: encodeData(quoteSingleHopAbi, [WXDAI, poolFee, bzzAmountOut]),
+  })
+
+  // Add slippage room on top of the quote.
+  const slippageBp = BigInt(Math.round(slippage * 10_000))
+  const maxAmountIn = (quotedAmountIn * (10_000n + slippageBp)) / 10_000n
+
+  if (opts.verbose) {
+    logger.info(
+      `Beeport batch: depth=${depth} bucketDepth=${bucketDepth} initialBalancePerChunk=${initialBalancePerChunk} bzzAmountOut=${bzzAmountOut} quotedAmountIn(wei)=${quotedAmountIn} maxAmountIn(wei)=${maxAmountIn}`,
+    )
+  }
+
+  // Random 32-byte nonce. The registry derives the batchId from
+  // keccak256(abi.encode(STAMPS_REGISTRY, nonce)).
+  const nonceHex = bytesToHex(new Uint8Array(randomBytes(32)))
+
+  const data = encodeData(createBatchNativeAbi, [
+    path,
+    maxAmountIn,
+    bzzAmountOut,
+    {
+      owner: signer,
+      nodeAddress: (opts.nodeAddress ?? signer) as Address,
+      initialBalancePerChunk,
+      depth,
+      bucketDepth,
+      nonce: nonceHex,
+      immutable_: true,
+    },
+  ])
+
+  logger.start(
+    `Buying Swarm batch via Beeport (depth=${depth}, ${durationSeconds}s)`,
+  )
+
+  const txHash = (await sendTransaction({
+    provider,
+    chainId: GNOSIS.id,
+    privateKey: opts.privateKey,
+    to: BEEPORT_REGISTRY,
+    data,
+    from: signer,
+    value: maxAmountIn,
+  })) as Hex
+
+  logger.info(`Submitted: ${GNOSIS.explorer}/tx/${txHash}`)
+
+  const receipt = await waitForTransaction(provider, txHash)
+
+  const batchId = extractBatchIdFromReceipt(
+    receipt.logs as unknown as readonly RpcLog[],
+    BATCH_CREATED_VIA_SWAP_TOPIC,
+    BEEPORT_REGISTRY,
+  )
+
+  logger.success(`Batch created: ${batchId}`)
+
+  return {
+    batchId,
+    txHash,
+    depth,
+    bucketDepth,
+    initialBalancePerChunk,
+    totalBzzAmount: bzzAmountOut,
+  }
+}
+
+/**
+ * Purchase an immutable Swarm postage batch via the canonical PostageStamp
+ * contract, paying with BZZ ERC-20 the caller already holds. Approves the
+ * required BZZ amount first.
+ */
+export const buyBatchViaBee = async (
+  opts: BuyBatchOptions,
+): Promise<BuyBatchResult> => {
+  const provider = Provider.from(fromHttp(opts.rpcUrl ?? GNOSIS.rpc))
+
+  const signer = fromPublicKey(getPublicKey({ privateKey: opts.privateKey }))
+  const sizeBytes = opts.sizeBytes ?? DEFAULT_BATCH_SIZE_BYTES
+  const durationSeconds = opts.durationSeconds ?? DEFAULT_BATCH_DURATION_SECONDS
+
+  const depth = getDepthForSize(sizeBytes)
+  const bucketDepth = DEFAULT_BUCKET_DEPTH
+  const initialBalancePerChunk = await getAmountForDuration({
+    provider,
+    durationSeconds,
+  })
+  const totalBzz = initialBalancePerChunk * (1n << BigInt(depth))
+
+  // Sanity check: caller must hold enough BZZ.
+  const bzzBalance = await getBzzBalance({ provider, account: signer })
+  if (bzzBalance < totalBzz) {
+    throw new Error(
+      `Insufficient BZZ balance (have ${bzzBalance}, need ${totalBzz})`,
+    )
+  }
+
+  if (opts.verbose) {
+    logger.info(
+      `Bee batch: depth=${depth} bucketDepth=${bucketDepth} initialBalancePerChunk=${initialBalancePerChunk} totalBzz=${totalBzz}`,
+    )
+  }
+
+  const nonceHex = bytesToHex(new Uint8Array(randomBytes(32)))
+
+  // 1. Approve BZZ to the PostageStamp contract.
+  logger.start(`Approving ${totalBzz} BZZ to PostageStamp`)
+  const approveTx = (await sendTransaction({
+    provider,
+    chainId: GNOSIS.id,
+    privateKey: opts.privateKey,
+    to: BZZ_TOKEN,
+    data: encodeData(erc20ApproveAbi, [POSTAGE_STAMP, totalBzz]),
+    from: signer,
+  })) as Hex
+  logger.info(`Approve: ${GNOSIS.explorer}/tx/${approveTx}`)
+  await waitForTransaction(provider, approveTx)
+
+  // 2. Create the batch.
+  logger.start(`Buying Swarm batch via PostageStamp (depth=${depth})`)
+  const txHash = (await sendTransaction({
+    provider,
+    chainId: GNOSIS.id,
+    privateKey: opts.privateKey,
+    to: POSTAGE_STAMP,
+    data: encodeData(createBatchAbi, [
+      signer,
+      initialBalancePerChunk,
+      depth,
+      bucketDepth,
+      nonceHex,
+      true,
+    ]),
+    from: signer,
+  })) as Hex
+  logger.info(`Submitted: ${GNOSIS.explorer}/tx/${txHash}`)
+
+  const receipt = await waitForTransaction(provider, txHash)
+
+  const batchId = extractBatchIdFromReceipt(
+    receipt.logs as unknown as readonly RpcLog[],
+    BATCH_CREATED_TOPIC,
+    POSTAGE_STAMP,
+  )
+
+  logger.success(`Batch created: ${batchId}`)
+
+  return {
+    batchId,
+    txHash,
+    depth,
+    bucketDepth,
+    initialBalancePerChunk,
+    totalBzzAmount: totalBzz,
+  }
+}

--- a/test/providers/beeport.test.ts
+++ b/test/providers/beeport.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'bun:test'
+import { createTar } from 'nanotar'
+
+// Force `constants.ts` to finish initialising before any individual provider
+// module gets imported — avoids a load-time TDZ cycle through
+// `logger.ts → constants.ts → providers/swarm/beeport.ts`.
+import '../../src/constants.js'
+
+import { PinningNotSupportedError } from '../../src/errors.js'
+import { uploadOnBeeport } from '../../src/providers/swarm/beeport.js'
+import {
+  getDepthForSize,
+  parseDuration,
+  parseSize,
+} from '../../src/utils/swarm-batch.js'
+
+const hasToken = Boolean(Bun.env.OMNIPIN_BEEPORT_TOKEN)
+const hasBatchId = Boolean(Bun.env.OMNIPIN_BEEPORT_BATCH_ID)
+
+describe('Beeport', () => {
+  describe('upload', () => {
+    it('should throw if pinning was chosen (first=false)', async () => {
+      await expect(
+        uploadOnBeeport({
+          first: false,
+          token: '',
+          bytes: new Uint8Array(),
+          name: 'test',
+          size: 0,
+          cid: '',
+        }),
+      ).rejects.toThrow(PinningNotSupportedError)
+    })
+
+    it('should throw MissingKeyError when no private key is set', async () => {
+      const previous = process.env.OMNIPIN_BEEPORT_TOKEN
+      delete process.env.OMNIPIN_BEEPORT_TOKEN
+      try {
+        await expect(
+          uploadOnBeeport({
+            first: true,
+            token: '',
+            bytes: new Uint8Array(),
+            name: 'test',
+            size: 0,
+            cid: '',
+          }),
+        ).rejects.toThrow('OMNIPIN_BEEPORT_TOKEN is missing')
+      } finally {
+        if (previous !== undefined) {
+          process.env.OMNIPIN_BEEPORT_TOKEN = previous
+        }
+      }
+    })
+
+    // Live upload — only runs if both the signing key and a pre-purchased
+    // batch id are available. Auto-purchase is intentionally not exercised in
+    // CI because it sends a real Gnosis tx.
+    it.skipIf(!hasToken || !hasBatchId)(
+      'should upload to Beeport with a configured batch id',
+      async () => {
+        // Beeport (and Bee) treat the upload body as a TAR-encoded collection.
+        const html = new TextEncoder().encode(
+          '<!doctype html><title>omnipin beeport test</title>hello',
+        )
+        const tar = createTar([{ name: 'index.html', data: html }]) as Uint8Array
+        const bytes = new Uint8Array(tar.byteLength)
+        bytes.set(tar)
+        const result = await uploadOnBeeport({
+          first: true,
+          token: '',
+          bytes: bytes as Uint8Array<ArrayBuffer>,
+          name: 'omnipin-beeport-test',
+          size: bytes.byteLength,
+          cid: '',
+          verbose: true,
+        })
+        expect(result.rID).toMatch(/^[0-9a-f]{64}$/)
+        expect(result.cid).toMatch(/^[a-z2-7]+$/)
+      },
+      { timeout: 60_000 },
+    )
+  })
+})
+
+describe('swarm-batch helpers', () => {
+  describe('parseSize', () => {
+    it('parses MB / MiB correctly', () => {
+      expect(parseSize('110MB')).toBe(110n * 1000n * 1000n)
+      expect(parseSize('110MiB')).toBe(110n * 1024n * 1024n)
+    })
+
+    it('parses GB / GiB correctly', () => {
+      expect(parseSize('1GB')).toBe(1_000_000_000n)
+      expect(parseSize('1GiB')).toBe(1_073_741_824n)
+    })
+
+    it('parses bare byte counts', () => {
+      expect(parseSize('1024')).toBe(1024n)
+      expect(parseSize('1024B')).toBe(1024n)
+    })
+
+    it('throws on invalid input', () => {
+      expect(() => parseSize('not-a-size')).toThrow()
+    })
+  })
+
+  describe('parseDuration', () => {
+    it('parses days / hours / minutes / weeks', () => {
+      expect(parseDuration('30d')).toBe(2_592_000n)
+      expect(parseDuration('24h')).toBe(86_400n)
+      expect(parseDuration('60m')).toBe(3600n)
+      expect(parseDuration('1w')).toBe(604_800n)
+    })
+
+    it('parses bare second counts', () => {
+      expect(parseDuration('3600')).toBe(3600n)
+      expect(parseDuration('3600s')).toBe(3600n)
+    })
+
+    it('throws on invalid input', () => {
+      expect(() => parseDuration('not-a-duration')).toThrow()
+    })
+  })
+
+  describe('getDepthForSize', () => {
+    it('returns depth 19 for 110 MB', () => {
+      expect(getDepthForSize(110n * 1000n * 1000n)).toBe(19)
+    })
+
+    it('returns depth 17 for very small sizes', () => {
+      expect(getDepthForSize(1000n)).toBe(17)
+    })
+
+    it('returns depth 20 for 500 MB', () => {
+      expect(getDepthForSize(500n * 1000n * 1000n)).toBe(20)
+    })
+  })
+})


### PR DESCRIPTION
Adds a new Swarm upload provider backed by the [Beeport proxy](https://beeport.ethswarm.org) so users can upload to Swarm without running their own Bee node, plus a standalone `omnipin batch` command for purchasing postage stamp batches on Gnosis.

## Provider (`BEEPORT_TOKEN`)

- Signs uploads with `OMNIPIN_BEEPORT_TOKEN` (private key, separate from `OMNIPIN_PK` which stays reserved for ENS / Safe writes) using EIP-191 `personal_sign` — verified against `viem.verifyMessage` (Beeport's backend uses viem to verify).
- Batch resolution order:
  1. `OMNIPIN_BEEPORT_BATCH_ID` env var
  2. In-memory cache (skips lookup on repeat uploads)
  3. On-chain lookup of batches the signer owns via Beeport's `StampsRegistry.getOwnerBatches`, cross-checked with the Bee node's `/stamps/<id>` (`usable: true`) so we never pick a not-yet-indexed batch
  4. Otherwise throw `MissingKeyError('BEEPORT_BATCH_ID')`
- **No auto-purchase during deploy.** Freshly minted batches take several minutes before the Bee node indexes them; auto-purchasing inside `omnipin deploy` would make the very first upload after install fail with "batch with id not found". The provider fails fast and points users at the `batch` command instead.

## `omnipin batch --provider=...`

| `--provider` | Method | Asset | Signing key |
|---|---|---|---|
| `Beeport` | `createBatchNative` on the SushiSwapStampsRouter (`0xf244cC25…`) — uses `quoteSingleHop` for accurate slippage | native xDAI | `OMNIPIN_BEEPORT_TOKEN` |
| `Bee` | `BZZ.approve` + `createBatch` on the canonical PostageStamp (`0x45a1502…`) | BZZ ERC-20 | `OMNIPIN_PK` |

- Defaults: 110 MB capacity, 30 days, depth auto-computed from bee-js's effective-size breakpoints (depth 17–34, `ENCRYPTION_OFF` / `REDUNDANCY_OFF`). Batches are always immutable.
- Shared parsers (`parseSize`, `parseDuration`) accept e.g. `1.5GB`, `512KiB`, `30d`, `24h`.
- Batch IDs are extracted from the `BatchCreatedViaSwap` / `BatchCreated` events in the tx receipt.

## Verified live on Gnosis

- `batch --provider=Beeport` — purchased a batch via SushiSwap swap (`createBatchNative`); confirmed `BatchCreated` event, batch shows up in the registry.
- `batch --provider=Bee` — purchased a batch via approve + `createBatch`; confirmed `owner = signer`, `depth = 17`, `immutable = true`, `remainingBalance` consistent with `lastPrice`.
- Beeport upload with `OMNIPIN_BEEPORT_BATCH_ID` set → HTTP 201, content reachable via `bzz.limo`.
- Beeport upload without the env var → on-chain lookup picked the indexed batch over the not-yet-indexed one, HTTP 201, content reachable via `bzz.limo`.

## Tests

- Unit tests for `parseSize`, `parseDuration`, `getDepthForSize`
- Provider guard-rails (`PinningNotSupportedError`, `MissingKeyError`)
- Skipped live upload test that runs only when both `OMNIPIN_BEEPORT_TOKEN` and `OMNIPIN_BEEPORT_BATCH_ID` are set

## Files

| File | Purpose |
|------|---------|
| `src/providers/swarm/beeport.ts` | Upload provider |
| `src/utils/swarm-batch.ts` | On-chain helpers (ABIs, sizing, path encoding, batch purchase + lookup) |
| `src/actions/batch.ts` | `omnipin batch` action |
| `src/constants.ts` | Register `BEEPORT_TOKEN` |
| `src/cli.ts` | Add `batch` command |
| `src/actions/deploy.ts` | Pass `beeportURL` + non-empty `name` to swarm providers |
| `src/deps.ts` | Re-export `randomBytes` for batch nonces |
| `test/providers/beeport.test.ts` | Unit + live tests |