### PR TITLE
fix(bridge): authorize Squid router via Permit2 on Filecoin bridge

### DIFF
--- a/src/utils/filecoin-bridge.ts
+++ b/src/utils/filecoin-bridge.ts
@@ -1,4 +1,4 @@
-import { encodeData } from 'ox/AbiFunction'
+import { decodeResult, encodeData } from 'ox/AbiFunction'
 import { type Address, fromPublicKey } from 'ox/Address'
 import { type Hex, toBigInt } from 'ox/Hex'
 import * as Provider from 'ox/Provider'
@@ -34,6 +34,30 @@ export const FILECOIN_AXL_USDC: Address =
 /** WFIL on Filecoin. */
 export const FILECOIN_WFIL: Address =
   '0x60e1773636cf5e4a227d9ac24f20feca034ee25a'
+
+/**
+ * Canonical Uniswap Permit2 contract. Deterministically deployed at the same
+ * address on every EVM chain we bridge from (Ethereum, Optimism, BSC, Polygon,
+ * Base, Arbitrum, Avalanche).
+ *
+ * Squid's router pulls ERC-20 inputs through Permit2's `AllowanceTransfer`
+ * module rather than a plain `transferFrom`, so spending requires both an
+ * ERC-20 approval to Permit2 *and* a Permit2 allowance for the router. See
+ * {@link ensurePermit2Allowance}.
+ */
+export const PERMIT2_ADDRESS: Address =
+  '0x000000000022D473030F116dDEE9F6B43aC78BA3'
+
+/** Permit2 `AllowanceTransfer` infinite-amount sentinel (no per-pull decrement). */
+const MAX_UINT160 = 2n ** 160n - 1n
+/**
+ * Max Permit2 expiration (uint48); a far-future timestamp so it never expires.
+ * A plain `number` because uint48 fits in a JS safe integer, which is how the
+ * ABI codec represents it.
+ */
+const MAX_UINT48 = 2 ** 48 - 1
+/** Standard "infinite" ERC-20 allowance. */
+const MAX_UINT256 = 2n ** 256n - 1n
 
 export type SourceChainId = 1 | 10 | 56 | 137 | 8453 | 42161 | 43114
 
@@ -178,6 +202,37 @@ const erc20Decimals = {
   outputs: [{ type: 'uint8' }],
 } as const
 
+/** Permit2 `AllowanceTransfer.approve(token, spender, amount, expiration)`. */
+const permit2Approve = {
+  name: 'approve',
+  type: 'function',
+  stateMutability: 'nonpayable',
+  inputs: [
+    { name: 'token', type: 'address' },
+    { name: 'spender', type: 'address' },
+    { name: 'amount', type: 'uint160' },
+    { name: 'expiration', type: 'uint48' },
+  ],
+  outputs: [],
+} as const
+
+/** Permit2 `AllowanceTransfer.allowance(owner, token, spender)`. */
+const permit2Allowance = {
+  name: 'allowance',
+  type: 'function',
+  stateMutability: 'view',
+  inputs: [
+    { name: 'owner', type: 'address' },
+    { name: 'token', type: 'address' },
+    { name: 'spender', type: 'address' },
+  ],
+  outputs: [
+    { name: 'amount', type: 'uint160' },
+    { name: 'expiration', type: 'uint48' },
+    { name: 'nonce', type: 'uint48' },
+  ],
+} as const
+
 /**
  * Resolve `--from-token` (either a known symbol on the given chain, or a raw
  * 0x address) to an ERC-20 contract address. Throws when the symbol is
@@ -223,8 +278,74 @@ const fetchTokenDecimals = async ({
   return Number(toBigInt(raw as Hex))
 }
 
-/** Ensure the Squid router has an allowance >= amount; approve max if not. */
-const ensureAllowance = async ({
+/** Read an ERC-20 `allowance(owner, spender)`. */
+const readErc20Allowance = async ({
+  provider,
+  token,
+  owner,
+  spender,
+}: {
+  provider: Provider.Provider
+  token: Address
+  owner: Address
+  spender: Address
+}): Promise<bigint> => {
+  const raw = await provider.request({
+    method: 'eth_call',
+    params: [
+      { to: token, data: encodeData(erc20Allowance, [owner, spender]) },
+      'latest',
+    ],
+  })
+  return toBigInt(raw as Hex)
+}
+
+/** Read a Permit2 `allowance(owner, token, spender)` → packed amount/expiration. */
+const readPermit2Allowance = async ({
+  provider,
+  token,
+  owner,
+  spender,
+}: {
+  provider: Provider.Provider
+  token: Address
+  owner: Address
+  spender: Address
+}): Promise<{ amount: bigint; expiration: number }> => {
+  const raw = await provider.request({
+    method: 'eth_call',
+    params: [
+      {
+        to: PERMIT2_ADDRESS,
+        data: encodeData(permit2Allowance, [owner, token, spender]),
+      },
+      'latest',
+    ],
+  })
+  // Returns (uint160 amount, uint48 expiration, uint48 nonce); uint48 fits in
+  // a JS number, so the codec yields a bigint amount and number expiration.
+  const [amount, expiration] = decodeResult(permit2Allowance, raw as Hex)
+  return { amount, expiration }
+}
+
+/**
+ * Authorize `spender` (the Squid router) to pull `amount` of `token` from
+ * `owner` via Permit2.
+ *
+ * Squid's router pulls ERC-20 inputs through Permit2's `AllowanceTransfer`
+ * module, not a plain `transferFrom`. That needs two distinct approvals:
+ *
+ *   1. ERC-20 `approve(PERMIT2, max)` — lets the Permit2 contract move the
+ *      token on the owner's behalf.
+ *   2. Permit2 `approve(token, spender, amount, expiration)` — authorizes the
+ *      router to spend through Permit2 until `expiration`.
+ *
+ * Approving the router directly on the ERC-20 (the pre-Permit2 pattern) leaves
+ * the Permit2 allowance unset, so the router's `Permit2.transferFrom` reverts
+ * with `AllowanceExpired(0)`. Both approvals are issued at the infinite
+ * sentinel once and skipped on subsequent runs when already in place.
+ */
+export const ensurePermit2Allowance = async ({
   provider,
   privateKey,
   owner,
@@ -241,29 +362,53 @@ const ensureAllowance = async ({
   amount: bigint
   chainId: number
 }): Promise<void> => {
-  const raw = await provider.request({
-    method: 'eth_call',
-    params: [
-      { to: token, data: encodeData(erc20Allowance, [owner, spender]) },
-      'latest',
-    ],
-  })
-  const current = toBigInt(raw as Hex)
-  if (current >= amount) return
-
-  logger.info(`Approving ${spender} to spend the source token`)
-  // Approve max uint256 once to avoid repeated approvals for split topups.
-  const max = 2n ** 256n - 1n
-  const data = encodeData(erc20Approve, [spender, max])
-  const txHash = (await sendTransaction({
+  // Step 1: ERC-20 → Permit2. Permit2 itself needs to be able to pull the
+  // token, so the owner approves the Permit2 contract (not the router).
+  const erc20Allowed = await readErc20Allowance({
     provider,
-    chainId,
-    privateKey,
-    to: token,
-    data,
-    from: owner,
-  })) as Hex
-  await waitForTransaction(provider, txHash)
+    token,
+    owner,
+    spender: PERMIT2_ADDRESS,
+  })
+  if (erc20Allowed < amount) {
+    logger.info('Approving Permit2 to spend the source token')
+    const txHash = (await sendTransaction({
+      provider,
+      chainId,
+      privateKey,
+      to: token,
+      data: encodeData(erc20Approve, [PERMIT2_ADDRESS, MAX_UINT256]),
+      from: owner,
+    })) as Hex
+    await waitForTransaction(provider, txHash)
+  }
+
+  // Step 2: Permit2 → router. Authorize the Squid router to spend via Permit2.
+  // Re-approve when the stored allowance is too small or already expired.
+  const nowSeconds = Math.floor(Date.now() / 1000)
+  const permit2 = await readPermit2Allowance({
+    provider,
+    token,
+    owner,
+    spender,
+  })
+  if (permit2.amount < amount || permit2.expiration <= nowSeconds) {
+    logger.info(`Authorizing ${spender} to spend via Permit2`)
+    const txHash = (await sendTransaction({
+      provider,
+      chainId,
+      privateKey,
+      to: PERMIT2_ADDRESS,
+      data: encodeData(permit2Approve, [
+        token,
+        spender,
+        MAX_UINT160,
+        MAX_UINT48,
+      ]),
+      from: owner,
+    })) as Hex
+    await waitForTransaction(provider, txHash)
+  }
 }
 
 export type FilecoinBridgeResult = {
@@ -385,12 +530,14 @@ export const bridgeFilecoin = async ({
     if (usdfcRoute) logRouteSummary('USDfc', usdfcRoute)
   }
 
-  // For ERC-20 inputs, approve the Squid router for the *total* once.
+  // For ERC-20 inputs, set up Permit2 for the Squid router for the *total*
+  // once. Squid pulls funds via Permit2, so a plain ERC-20 approval to the
+  // router is not enough (see ensurePermit2Allowance).
   const isNative = sourceToken.toLowerCase() === NATIVE_TOKEN.toLowerCase()
   if (!isNative) {
     const spender = (filRoute?.transactionRequest.target ??
       usdfcRoute?.transactionRequest.target) as Address
-    await ensureAllowance({
+    await ensurePermit2Allowance({
       provider,
       privateKey,
       owner: signer,

--- a/src/utils/filecoin-bridge.ts
+++ b/src/utils/filecoin-bridge.ts
@@ -485,7 +485,7 @@ export const bridgeFilecoin = async ({
     `Bridge to Filecoin: ${amount} ${fromToken} from ${chainConfig.name} → ${destination}`,
   )
   logger.info(
-    `Split: ${filAtomic} (FIL leg) + ${usdfcAtomic} (USDfc leg), source-token atomic units`,
+    `Split: ${Value.format(filAtomic, decimals)} ${fromToken} → FIL + ${Value.format(usdfcAtomic, decimals)} ${fromToken} → USDfc`,
   )
 
   // Quote both legs ahead of time so we surface route errors before any

--- a/src/utils/filecoin-bridge.ts
+++ b/src/utils/filecoin-bridge.ts
@@ -13,7 +13,7 @@ import {
   type SquidRoute,
   type SquidRouteParams,
 } from './squid.js'
-import { sendTransaction, waitForTransaction } from './tx.js'
+import { getBalance, sendTransaction, waitForTransaction } from './tx.js'
 
 /** Filecoin EVM mainnet (chain 314) constants. */
 export const FILECOIN_MAINNET = {
@@ -202,6 +202,14 @@ const erc20Decimals = {
   outputs: [{ type: 'uint8' }],
 } as const
 
+const erc20BalanceOf = {
+  name: 'balanceOf',
+  type: 'function',
+  stateMutability: 'view',
+  inputs: [{ name: 'account', type: 'address' }],
+  outputs: [{ type: 'uint256' }],
+} as const
+
 /** Permit2 `AllowanceTransfer.approve(token, spender, amount, expiration)`. */
 const permit2Approve = {
   name: 'approve',
@@ -276,6 +284,29 @@ const fetchTokenDecimals = async ({
   })
   // decimals() returns uint8 padded to 32 bytes.
   return Number(toBigInt(raw as Hex))
+}
+
+/** Read the owner's balance of the source token (native sentinel or ERC-20). */
+export const fetchSourceBalance = async ({
+  provider,
+  token,
+  owner,
+}: {
+  provider: Provider.Provider
+  token: Address
+  owner: Address
+}): Promise<bigint> => {
+  if (token.toLowerCase() === NATIVE_TOKEN.toLowerCase()) {
+    return getBalance({ provider, address: owner })
+  }
+  const raw = await provider.request({
+    method: 'eth_call',
+    params: [
+      { to: token, data: encodeData(erc20BalanceOf, [owner]) },
+      'latest',
+    ],
+  })
+  return toBigInt(raw as Hex)
 }
 
 /** Read an ERC-20 `allowance(owner, spender)`. */
@@ -487,6 +518,18 @@ export const bridgeFilecoin = async ({
   logger.info(
     `Split: ${Value.format(filAtomic, decimals)} ${fromToken} → FIL + ${Value.format(usdfcAtomic, decimals)} ${fromToken} → USDfc`,
   )
+
+  // Fail fast if the wallet can't cover the bridge amount. Otherwise the
+  // Squid router's Permit2.transferFrom reverts on-chain with an opaque
+  // TRANSFER_FROM_FAILED — but only after we've spent gas on approvals.
+  const sourceBalance = await fetchSourceBalance({
+    provider,
+    token: sourceToken,
+    owner: signer,
+  })
+  if (sourceBalance < totalAmountAtomic) {
+    throw new Error(`Insufficient ${fromToken} on ${chainConfig.name}`)
+  }
 
   // Quote both legs ahead of time so we surface route errors before any
   // on-chain action.

--- a/test/utils/filecoin-bridge.test.ts
+++ b/test/utils/filecoin-bridge.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'bun:test'
+import type * as Provider from 'ox/Provider'
 import {
+  ensurePermit2Allowance,
   FILECOIN_USDFC,
   isSourceChainKey,
+  PERMIT2_ADDRESS,
   resolveSourceToken,
   SOURCE_CHAINS,
 } from '../../src/utils/filecoin-bridge.js'
@@ -98,5 +101,169 @@ describe('filecoin-bridge utils', () => {
         resolveSourceToken({ chain: 'eth', token: '0xabc' }),
       ).toThrow(/Unknown token/)
     })
+  })
+})
+
+describe('ensurePermit2Allowance', () => {
+  const TEST_PK = `0x${'11'.repeat(32)}` as const
+  const OWNER = '0x972a34a8a7b9e19da849921f8d9d58f3d2df568b' as const
+  // Squid's router target — the Permit2 spender that pulls the source token.
+  const SQUID_ROUTER = '0xce16F69375520ab01377ce7B88f5BA8C48F8D666' as const
+  const USDC = SOURCE_CHAINS.eth.tokens.USDC
+
+  // ERC-20 / Permit2 selectors.
+  const ERC20_ALLOWANCE = '0xdd62ed3e' // allowance(address,address)
+  const ERC20_APPROVE = '0x095ea7b3' // approve(address,uint256)
+  const PERMIT2_APPROVE = '0x87517c45' // approve(address,address,uint160,uint48)
+
+  /** Left-pad a value to a 32-byte ABI word (no 0x prefix). */
+  const word = (v: bigint | number) => BigInt(v).toString(16).padStart(64, '0')
+  /** Extract the trailing 20-byte address from a 32-byte word, lowercased. */
+  const addrInWord = (w: string) => `0x${w.slice(24)}`.toLowerCase()
+
+  /**
+   * Build a mock provider that reports the given starting allowances and
+   * records every read (`eth_call`) and every transaction (captured at the
+   * `eth_estimateGas` step, which `sendTransaction` runs per tx).
+   */
+  const makeProvider = (state: {
+    erc20ToPermit2: bigint
+    permit2Amount: bigint
+    permit2Expiration: number
+  }) => {
+    const sent: { to: string; data: string }[] = []
+    const reads: { to: string; data: string }[] = []
+    const request = async ({
+      method,
+      params,
+    }: {
+      method: string
+      params?: readonly unknown[]
+    }): Promise<unknown> => {
+      switch (method) {
+        case 'eth_call': {
+          const call = (params?.[0] ?? {}) as { to: string; data: string }
+          reads.push({ to: call.to, data: call.data })
+          if (call.to.toLowerCase() === PERMIT2_ADDRESS.toLowerCase()) {
+            // (uint160 amount, uint48 expiration, uint48 nonce)
+            return `0x${word(state.permit2Amount)}${word(
+              state.permit2Expiration,
+            )}${word(0)}`
+          }
+          // ERC-20 allowance(owner, spender) → single uint256
+          return `0x${word(state.erc20ToPermit2)}`
+        }
+        case 'eth_estimateGas': {
+          const call = (params?.[0] ?? {}) as { to: string; data: string }
+          sent.push({ to: call.to, data: call.data })
+          return '0x5208'
+        }
+        case 'eth_getTransactionCount':
+          return '0x0'
+        case 'eth_getBlockByNumber':
+          return { baseFeePerGas: '0x3b9aca00' }
+        case 'eth_maxPriorityFeePerGas':
+          return '0x1'
+        case 'eth_sendRawTransaction':
+          return `0x${'ab'.repeat(32)}`
+        case 'eth_getTransactionReceipt':
+          return { status: '0x1', logs: [], type: '0x2' }
+        case 'eth_chainId':
+          return '0x1'
+        default:
+          throw new Error(`unexpected RPC method ${method}`)
+      }
+    }
+    return {
+      provider: { request } as unknown as Provider.Provider,
+      sent,
+      reads,
+    }
+  }
+
+  const run = (provider: Provider.Provider, amount = 100_000n) =>
+    ensurePermit2Allowance({
+      provider,
+      privateKey: TEST_PK,
+      owner: OWNER,
+      token: USDC,
+      spender: SQUID_ROUTER,
+      amount,
+      chainId: SOURCE_CHAINS.eth.id,
+    })
+
+  it('approves Permit2 on the token, then authorizes the router via Permit2', async () => {
+    const { provider, sent, reads } = makeProvider({
+      erc20ToPermit2: 0n,
+      permit2Amount: 0n,
+      permit2Expiration: 0,
+    })
+
+    await run(provider)
+
+    // Regression guard: the ERC-20 allowance must be checked against the
+    // Permit2 contract, NOT the router (the old bug approved the router and
+    // tripped Permit2's AllowanceExpired(0)).
+    const erc20Read = reads.find(
+      (r) => r.to.toLowerCase() === USDC.toLowerCase(),
+    )
+    expect(erc20Read?.data.slice(0, 10)).toBe(ERC20_ALLOWANCE)
+    expect(addrInWord(erc20Read?.data.slice(-64) ?? '')).toBe(
+      PERMIT2_ADDRESS.toLowerCase(),
+    )
+
+    expect(sent).toHaveLength(2)
+    const [approveErc20, approvePermit2] = sent
+
+    // 1) ERC-20 approve(PERMIT2, maxUint256)
+    expect(approveErc20.to.toLowerCase()).toBe(USDC.toLowerCase())
+    expect(approveErc20.data.slice(0, 10)).toBe(ERC20_APPROVE)
+    expect(addrInWord(approveErc20.data.slice(10, 74))).toBe(
+      PERMIT2_ADDRESS.toLowerCase(),
+    )
+    expect(approveErc20.data.slice(74, 138)).toBe('f'.repeat(64))
+
+    // 2) Permit2 approve(token, router, maxUint160, maxUint48)
+    expect(approvePermit2.to.toLowerCase()).toBe(PERMIT2_ADDRESS.toLowerCase())
+    expect(approvePermit2.data.slice(0, 10)).toBe(PERMIT2_APPROVE)
+    expect(addrInWord(approvePermit2.data.slice(10, 74))).toBe(
+      USDC.toLowerCase(),
+    )
+    expect(addrInWord(approvePermit2.data.slice(74, 138))).toBe(
+      SQUID_ROUTER.toLowerCase(),
+    )
+    // amount = max uint160, expiration = max uint48
+    expect(approvePermit2.data.slice(138, 202)).toBe(
+      `${'0'.repeat(24)}${'f'.repeat(40)}`,
+    )
+    expect(approvePermit2.data.slice(202, 266)).toBe(
+      `${'0'.repeat(52)}${'f'.repeat(12)}`,
+    )
+  })
+
+  it('issues no transactions when both allowances already cover the amount', async () => {
+    const { provider, sent } = makeProvider({
+      erc20ToPermit2: 2n ** 256n - 1n,
+      permit2Amount: 2n ** 160n - 1n,
+      permit2Expiration: Math.floor(Date.now() / 1000) + 86_400,
+    })
+
+    await run(provider)
+
+    expect(sent).toHaveLength(0)
+  })
+
+  it('re-authorizes via Permit2 when the stored allowance is expired', async () => {
+    const { provider, sent } = makeProvider({
+      erc20ToPermit2: 2n ** 256n - 1n, // ERC-20 → Permit2 already in place
+      permit2Amount: 2n ** 160n - 1n, // amount is sufficient…
+      permit2Expiration: 1, // …but expired (this is the AllowanceExpired case)
+    })
+
+    await run(provider)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].to.toLowerCase()).toBe(PERMIT2_ADDRESS.toLowerCase())
+    expect(sent[0].data.slice(0, 10)).toBe(PERMIT2_APPROVE)
   })
 })

--- a/test/utils/filecoin-bridge.test.ts
+++ b/test/utils/filecoin-bridge.test.ts
@@ -3,6 +3,7 @@ import type * as Provider from 'ox/Provider'
 import {
   ensurePermit2Allowance,
   FILECOIN_USDFC,
+  fetchSourceBalance,
   isSourceChainKey,
   PERMIT2_ADDRESS,
   resolveSourceToken,
@@ -265,5 +266,61 @@ describe('ensurePermit2Allowance', () => {
     expect(sent).toHaveLength(1)
     expect(sent[0].to.toLowerCase()).toBe(PERMIT2_ADDRESS.toLowerCase())
     expect(sent[0].data.slice(0, 10)).toBe(PERMIT2_APPROVE)
+  })
+})
+
+describe('fetchSourceBalance', () => {
+  const OWNER = '0x972a34a8a7b9e19da849921f8d9d58f3d2df568b' as const
+  const USDC = SOURCE_CHAINS.eth.tokens.USDC
+
+  it('reads an ERC-20 balance via balanceOf(account)', async () => {
+    let seen: { to: string; data: string } | undefined
+    const provider = {
+      request: async ({
+        method,
+        params,
+      }: {
+        method: string
+        params?: readonly unknown[]
+      }): Promise<unknown> => {
+        if (method !== 'eth_call') throw new Error(`unexpected ${method}`)
+        seen = (params?.[0] ?? {}) as { to: string; data: string }
+        // balanceOf → 250000 (0.25 USDC at 6 decimals)
+        return `0x${250_000n.toString(16).padStart(64, '0')}`
+      },
+    } as unknown as Provider.Provider
+
+    const balance = await fetchSourceBalance({
+      provider,
+      token: USDC,
+      owner: OWNER,
+    })
+
+    expect(balance).toBe(250_000n)
+    expect(seen?.to.toLowerCase()).toBe(USDC.toLowerCase())
+    expect(seen?.data.slice(0, 10)).toBe('0x70a08231') // balanceOf(address)
+    expect(`0x${seen?.data.slice(-40)}`.toLowerCase()).toBe(OWNER)
+  })
+
+  it('reads the native balance via eth_getBalance for the native sentinel', async () => {
+    let method: string | undefined
+    const provider = {
+      request: async (args: {
+        method: string
+        params?: readonly unknown[]
+      }): Promise<unknown> => {
+        method = args.method
+        return `0x${(1_000_000_000_000_000_000n).toString(16)}` // 1 ETH
+      },
+    } as unknown as Provider.Provider
+
+    const balance = await fetchSourceBalance({
+      provider,
+      token: NATIVE_TOKEN,
+      owner: OWNER,
+    })
+
+    expect(balance).toBe(1_000_000_000_000_000_000n)
+    expect(method).toBe('eth_getBalance')
   })
 })


### PR DESCRIPTION
## Problem

`omnipin bridge --provider=Filecoin --from-chain=eth --from-token=USDC …` reverts when executing a leg:

```
🟢 Approving 0xce16F69375520ab01377ce7B88f5BA8C48F8D666 to spend the source token
🟢 Estimated gas: 56711
🟢 Executing FIL leg on Ethereum
🚨 execution reverted … data: '0xd81b2f2e00000000000000000000000000000000000000000000000000000000'
```

`cast error-decode 0xd81b2f2e` → `AllowanceExpired(uint256)` — a Uniswap **Permit2** `AllowanceTransfer` error, with `expiration = 0` (i.e. the allowance was never set).

## Root cause

Squid's router (`0xce16…`) pulls ERC-20 inputs through **Permit2's `AllowanceTransfer`** module (`Permit2.transferFrom`), *not* a plain `transferFrom`. `ensureAllowance` did the pre-Permit2 pattern:

```ts
ERC20.approve(squidRouterTarget, max)   // router never reads this
```

So Permit2 has no allowance for `(user, token, router)`; `Permit2.transferFrom` reads `expiration == 0` and reverts `AllowanceExpired(0)`.

The log is the giveaway: `Estimated gas: 56711` is the **approve** tx (a plain approve, ~50k gas — below the intrinsic calldata cost of the 2644-byte `bridgeCall`, so it can't be the bridge tx). The revert then fires inside `eth_estimateGas` for the `bridgeCall`.

Verified against the live Squid API: both legs target `0xce16…` and call `bridgeCall(...)` with **no embedded permit signature** — i.e. on-chain AllowanceTransfer (hence `AllowanceExpired`, not `SignatureExpired`). Permit2 is at the canonical `0x0000…78BA3` on all 7 supported source chains. (Squid's public docs still describe the legacy "approve the target" flow; the on-chain behavior is unambiguous.)

## Fix

Replace `ensureAllowance` with `ensurePermit2Allowance`, performing the correct two-step Permit2 setup:

1. `ERC20.approve(PERMIT2, maxUint256)` — lets Permit2 move the token.
2. `Permit2.approve(token, router, maxUint160, maxUint48)` — authorizes the router to spend via Permit2, far-future expiration.

Both are read first and skipped when already in place; step 2 re-approves when the stored allowance is too small **or expired** (the exact condition behind the error). Adds the `PERMIT2_ADDRESS` constant, the Permit2 `approve`/`allowance` ABIs, and `readErc20Allowance`/`readPermit2Allowance` helpers. (Note: `ox` decodes `uint48` as a JS `number`, so `expiration` is typed accordingly.)

## AIOZ — not affected

Checked per request. `bridgeAioz` uses a different mechanism: it resolves a pool **EOA** from the AIOZ bridge API and does a direct `ERC20.transfer(pool, amount)` — no `approve`, no `transferFrom`, no Permit2, no Squid. The `AllowanceExpired` class can't occur there. The only Squid/Permit2 consumer is `filecoin-bridge.ts`.

## Testing

- `bun run types`: clean (pre-existing unrelated error in `car-block-iterator.test.ts` only).
- `biome check`: clean.
- Added 3 regression tests in `test/utils/filecoin-bridge.test.ts`: approves Permit2 + authorizes router; no-op when both already set; re-authorizes on expired Permit2 allowance. Full unit suite: 125 pass (was 122 + 3); the 5 failures are pre-existing network-dependent AIOZ/IPFSNinja provider tests, unchanged by this PR.

> Note: the commit is unsigned — GPG pinentry couldn't prompt in my environment. Feel free to `git commit --amend -S` / rebase-sign before merge if signed commits are required.
