### PR TITLE
fix(safe): use api.safe.global gateway and fail on propose errors

### DIFF
--- a/src/actions/ens.ts
+++ b/src/actions/ens.ts
@@ -208,8 +208,10 @@ export const ensAction = async ({
             }`,
           )
         } catch (e) {
-          logger.error('Failed to propose a transaction', e)
-          return
+          // Re-throw so the CLI exits with a non-zero status. Swallowing this
+          // here made `omnipin ens` report success even when the Safe proposal
+          // never went through (e.g. in CI), masking real failures.
+          throw new Error('Failed to propose a transaction', { cause: e })
         }
       }
     }

--- a/src/utils/safe.ts
+++ b/src/utils/safe.ts
@@ -13,8 +13,19 @@ import { type EIP3770Address, getEip3770Address } from './safe/eip3770.js'
 import type { SafeTransactionData } from './safe/types.js'
 import { SIMULATION_GAS_LIMIT } from './tx.js'
 
+// EIP-3155 short names used by the Safe Transaction Service gateway.
+const chainNameToSafeShortName: Record<ChainName, string> = {
+  mainnet: 'eth',
+  sepolia: 'sep',
+}
+
+// The legacy `https://safe-transaction-<network>.safe.global` hosts now reply
+// with a 308 redirect to the unified gateway below. `fetch` does not always
+// replay the POST body across that redirect, and the redirect itself serves an
+// HTML page — so callers ended up trying to `JSON.parse("<!DOCTYPE ...")`.
+// Targeting the gateway directly avoids the redirect entirely.
 export const chainToSafeApiUrl = (chainName: ChainName) =>
-  `https://safe-transaction-${chainName}.safe.global`
+  `https://api.safe.global/tx-service/${chainNameToSafeShortName[chainName]}`
 
 const zeroAddress = '0x0000000000000000000000000000000000000000'
 

--- a/src/utils/safe/propose.ts
+++ b/src/utils/safe/propose.ts
@@ -43,11 +43,24 @@ export const proposeTransaction = async ({
       },
     },
   )
+  // The Safe Transaction Service normally answers with JSON, but proxy/error
+  // pages (502s, redirects, rate limits) come back as HTML. Read the body as
+  // text first so a non-JSON response surfaces a useful error instead of a
+  // cryptic `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`.
+  const text = await res.text()
+
   if (!res.ok) {
-    const json = await res.json()
-    throw new Error(json.message, { cause: json })
+    let json: { message?: string; detail?: string } | undefined
+    try {
+      json = JSON.parse(text)
+    } catch {
+      throw new Error(
+        `Safe Transaction Service returned ${res.status} ${res.statusText} (non-JSON response)`,
+        { cause: text },
+      )
+    }
+    throw new Error(json?.message ?? json?.detail ?? text, { cause: json })
   }
 
-  const text = await res.text()
   console.log(text)
 }


### PR DESCRIPTION
## Problem

`omnipin ens --safe …` failed in CI with:

```
🚨 Failed to propose a transaction SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

`proposeTransaction` POSTs to the Safe Transaction Service. The URL used the legacy host `https://safe-transaction-<network>.safe.global`, which now responds with a **308 Permanent Redirect** to the unified gateway `https://api.safe.global/tx-service/<shortName>` and serves an **HTML** body. The code then ran `res.json()` on that HTML, producing the `Unexpected token '<'` crash.

Separately, the `ens` action caught the propose error, logged it, and `return`ed — so the CLI exited **0** and the GitHub Actions step reported **success** even though nothing was proposed.

## Fix

- **`chainToSafeApiUrl`**: target the current gateway directly — `https://api.safe.global/tx-service/{eth|sep}` — avoiding the 308 redirect entirely.
- **`proposeTransaction`**: read the body as text and parse JSON defensively, so a non-JSON/error page yields a clear message (`Safe Transaction Service returned <status> (non-JSON response)`) instead of a `JSON.parse` crash.
- **`ensAction`**: re-throw propose failures so the CLI exits non-zero instead of silently succeeding.

## Verification

- Live check: new URL resolves to `api.safe.global/tx-service/eth/...` with **no redirect** and a JSON response.
- `bun run types` clean (only a pre-existing unrelated test error remains).
- Biome lint clean on changed files.
- `bun run build` succeeds.
- `bun test test/utils/safe/ test/utils/ens.test.ts`: **14 pass, 0 fail**.