### PR TITLE
fix(aleph): correct STORE message format and add status

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ import {
   uploadOn4everland,
 } from './providers/ipfs/4everland.js'
 import { pinOnAioz } from './providers/ipfs/aioz.js'
-import { pinToAleph } from './providers/ipfs/aleph.js'
+import { pinToAleph, statusOnAleph } from './providers/ipfs/aleph.js'
 import {
   pinOnBlockfrost,
   statusOnBlockfrost,
@@ -146,6 +146,7 @@ export const PROVIDERS: Record<
   ALEPH_TOKEN: {
     name: 'Aleph',
     upload: pinToAleph,
+    status: statusOnAleph,
     supported: 'pin',
     protocol: 'ipfs',
   },

--- a/src/providers/ipfs/aleph.ts
+++ b/src/providers/ipfs/aleph.ts
@@ -1,18 +1,32 @@
 import { fromPublicKey } from 'ox/Address'
-import { toHex } from 'ox/Bytes'
+import * as Hash from 'ox/Hash'
 import type { Hex } from 'ox/Hex'
+import { fromNumber, fromString } from 'ox/Hex'
+import { getSignPayload } from 'ox/PersonalMessage'
 import { getPublicKey, sign } from 'ox/Secp256k1'
-import * as Signature from 'ox/Signature'
 import { DeployError } from '../../errors.js'
-import type { PinFunction } from '../../types.js'
+import type { PinFunction, PinStatus, StatusFunction } from '../../types.js'
 import { logger } from '../../utils/logger.js'
 
 const baseURL = 'https://api2.aleph.im'
-const te = new TextEncoder()
+const channel = 'POWERED-BY-OMNIPIN'
 
 const providerName = 'Aleph'
 
 type Chain = 'ETH' | 'AVAX' | 'BASE'
+
+/**
+ * Build an EIP-191 (`personal_sign`) signature over the Aleph verification
+ * buffer, serialized as `r || s || v` with `v` in {27, 28} — the format the
+ * Aleph CCN expects (equivalent to ethers' `wallet.signMessage`).
+ */
+const signVerificationBuffer = (privateKey: Hex, buffer: string): Hex => {
+  const sig = sign({ privateKey, payload: getSignPayload(fromString(buffer)) })
+  const r = fromNumber(sig.r, { size: 32 }).slice(2)
+  const s = fromNumber(sig.s, { size: 32 }).slice(2)
+  const v = (27 + sig.yParity).toString(16).padStart(2, '0')
+  return `0x${r}${s}${v}`
+}
 
 export const pinToAleph: PinFunction<{ token: Hex; chain: Chain }> = async ({
   cid,
@@ -20,38 +34,101 @@ export const pinToAleph: PinFunction<{ token: Hex; chain: Chain }> = async ({
   chain,
   verbose,
 }) => {
-  const message = {
-    chain,
-    sender: fromPublicKey(getPublicKey({ privateKey: token })),
-    type: 'STORE',
-    channel: 'POWERED-BY-OMNIPIN',
-    time: Date.now() / 1000,
+  const sender = fromPublicKey(getPublicKey({ privateKey: token }))
+  const time = Date.now() / 1000
+
+  // Inline STORE content; for an IPFS pin the inner `item_hash` is the CID.
+  const content = {
+    address: sender,
     item_type: 'ipfs',
     item_hash: cid,
-    item_content: null,
-    signature: undefined as Hex | undefined,
-    signature_type: 'eth_personal',
+    time,
   }
 
-  const stringToSign = `${message.sender}|${message.chain}|${message.type}|${message.item_hash}`
-  const sig = sign({
-    privateKey: token,
-    payload: toHex(te.encode(stringToSign)),
-  })
+  // The message is published inline: `item_content` is the serialized content
+  // and the message-level `item_hash` is its sha256 hash.
+  const itemContent = JSON.stringify(content)
+  const itemHash = Hash.sha256(fromString(itemContent), { as: 'Hex' }).slice(2)
 
-  message.signature = Signature.toHex(sig)
+  // Verification buffer is `chain\nsender\ntype\nitem_hash`.
+  const signature = signVerificationBuffer(
+    token,
+    [chain, sender, 'STORE', itemHash].join('\n'),
+  )
+
+  const message = {
+    chain,
+    sender,
+    channel,
+    time,
+    item_type: 'inline',
+    item_hash: itemHash,
+    item_content: itemContent,
+    signature,
+    type: 'STORE',
+  }
 
   const res = await fetch(`${baseURL}/api/v0/messages`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ message }),
+    body: JSON.stringify({ sync: false, message }),
   })
-  if (verbose) logger.request('POST', res.url, res.status)
-  const json = await res.json()
-  if (!res.ok)
-    throw new DeployError(providerName, json[0].msg, {
-      cause: JSON.stringify(json),
-    })
 
-  return { cid, status: json.publication_status.status }
+  if (verbose) logger.request('POST', res.url, res.status)
+
+  const text = await res.text()
+  let json: unknown
+  try {
+    json = JSON.parse(text)
+  } catch {
+    json = undefined
+  }
+
+  if (!res.ok) {
+    const reason =
+      (Array.isArray(json) && json[0]?.msg) ||
+      (json as { error?: string })?.error ||
+      text ||
+      'Pinning failed'
+    throw new DeployError(providerName, reason, { cause: text })
+  }
+
+  // Aleph accepts STORE messages into a queue; they become `pinned` only once
+  // processed/confirmed by the network. A successful POST means `queued`.
+  const accepted =
+    (json as { publication_status?: { status?: string } })?.publication_status
+      ?.status === 'success'
+
+  return { cid, status: accepted ? 'queued' : 'unknown' }
+}
+
+export const statusOnAleph: StatusFunction = async ({ cid, auth, verbose }) => {
+  if (!auth.token) return { pin: 'not pinned' }
+
+  const sender = fromPublicKey(getPublicKey({ privateKey: auth.token as Hex }))
+
+  const url = new URL(`${baseURL}/api/v0/messages.json`)
+  url.searchParams.set('addresses', sender)
+  url.searchParams.set('channels', channel)
+  url.searchParams.set('msgTypes', 'STORE')
+  url.searchParams.set('pagination', '200')
+
+  const res = await fetch(url)
+
+  if (verbose) logger.request('GET', res.url, res.status)
+
+  if (!res.ok) return { pin: 'unknown' }
+
+  const json = await res.json()
+  const messages: Array<{
+    confirmed?: boolean
+    content?: { item_hash?: string }
+  }> = json.messages ?? []
+
+  const match = messages.find((m) => m.content?.item_hash === cid)
+
+  if (!match) return { pin: 'not pinned' }
+
+  const pin: PinStatus = match.confirmed ? 'pinned' : 'queued'
+  return { pin }
 }


### PR DESCRIPTION
## Problem

The Aleph provider built and signed `STORE` messages incorrectly, so pins never actually landed on the network:

- The CID was placed directly as the message-level `item_hash`, with `item_content: null` and `item_type: 'ipfs'`.
- The signature was computed over a `|`-joined string (`sender|chain|type|item_hash`) using a raw secp256k1 signature.

Aleph's HTTP endpoint accepted the POST (`202`), but the message failed validation in the processing layer and was silently dropped — it never appeared in the message store. There was also no `status` function, so `omnipin status` reported nothing for Aleph.

## Fix

Build and sign the message per the Aleph spec (verified against `aleph-sdk-ts` / `pyaleph`):

- Inline publishing: `item_content` is the serialized `StoreContent` (`{ address, item_type: 'ipfs', item_hash: <CID>, time }`), and the message-level `item_hash` is `sha256(item_content)`.
- Sign the verification buffer `chain\nsender\nSTORE\nitem_hash` with **EIP-191 `personal_sign`**, serialized as `r || s || v` with `v` in `{27, 28}` (equivalent to ethers `wallet.signMessage`).
- Handle non-JSON error responses instead of throwing on `JSON.parse`.
- Map a successful submission to a valid `PinStatus` (`queued`).
- Add `statusOnAleph`, which queries processed `STORE` messages for the sender + channel and reports `pinned`/`queued`/`not pinned`. Registered in `constants.ts`.

## Verification

End-to-end against `api2.aleph.im` with a funded wallet and a CIDv1 dag-pb CID that's live on IPFS:

- `omnipin pin <cidv1>` -> `POST /api/v0/messages` `202`/`200`; message reaches `processed` (the old code never did).
- `omnipin status <cidv1>` -> `queued` (becomes `pinned` once anchored on-chain).

Types and lint clean on the changed files; no test regressions (pre-existing AIOZ/IPFSNinja live-API failures and the `filecoin.ts` ox type error are unrelated and present on `main`).