### PR TITLE
feat(fula): add Fula Land pinning provider and deposit support

### DIFF
--- a/docs/cli/deposit.md
+++ b/docs/cli/deposit.md
@@ -2,8 +2,8 @@
 
 Deposit already-held tokens into a provider's payment contract. Supported for **Filecoin** and **Fula**:
 
-- **Filecoin** — moves USDfc from the signer's Filecoin wallet into [Filecoin Pay](https://docs.filecoin.io), the storage payment contract used by the `Filecoin` IPFS provider.
-- **Fula** — transfers `$FULA` to Fula's payment vault. Fula has no chain of its own; `$FULA` is an ERC-20 on Ethereum and Base, so a deposit is a plain token transfer that credits your Fula account.
+- **Filecoin** — moves USDfc from the signer's Filecoin wallet into [Filecoin Pay](https://docs.filecoin.io).
+- **Fula** — transfers `$FULA` to Fula's payment vault. `$FULA` is an ERC-20 on Ethereum and Base, so a deposit is a plain token transfer.
 
 ```sh
 # Filecoin: deposit 5 USDfc into Filecoin Pay

--- a/docs/cli/deposit.md
+++ b/docs/cli/deposit.md
@@ -1,24 +1,46 @@
 # `omnipin deposit`
 
-Deposit already-held tokens into a provider's payment contract. Currently **Filecoin-only** — moves USDfc from the signer's Filecoin wallet into [Filecoin Pay](https://docs.filecoin.io), the storage payment contract used by the `Filecoin` IPFS provider.
+Deposit already-held tokens into a provider's payment contract. Supported for **Filecoin** and **Fula**:
+
+- **Filecoin** — moves USDfc from the signer's Filecoin wallet into [Filecoin Pay](https://docs.filecoin.io), the storage payment contract used by the `Filecoin` IPFS provider.
+- **Fula** — transfers `$FULA` to Fula's payment vault. Fula has no chain of its own; `$FULA` is an ERC-20 on Ethereum and Base, so a deposit is a plain token transfer that credits your Fula account.
 
 ```sh
-OMNIPIN_FILECOIN_TOKEN=0x... omnipin deposit --provider=Filecoin <amount>
+# Filecoin: deposit 5 USDfc into Filecoin Pay
+OMNIPIN_FILECOIN_TOKEN=0x... omnipin deposit --provider=Filecoin 5
+
+# Fula: deposit 10 $FULA to the vault (chain auto-detected from your balance)
+OMNIPIN_FULA_PK=0x... omnipin deposit --provider=Fula 10
+
+# Force a specific chain
+OMNIPIN_FULA_PK=0x... omnipin deposit --provider=Fula --chain=base 10
 ```
 
-`<amount>` is in whole USDfc tokens (18 decimals), e.g. `5` deposits 5 USDfc.
+`<amount>` is in whole tokens (18 decimals) — `5` deposits 5 USDfc, `10` deposits 10 `$FULA`.
 
-Use `deposit` when you want to skip `omnipin deploy --providers=Filecoin`'s auto-fund flow, when you already hold USDfc on Filecoin, or to top up your storage allowance from leftover USDfc. To bridge from another chain first, use [`omnipin bridge`](./bridge).
+Use `deposit` when you want to skip `omnipin deploy`'s auto-fund flow, when you already hold the payment token, or to top up your storage allowance. To bridge from another chain first (Filecoin), use [`omnipin bridge`](./bridge). To acquire `$FULA`, swap for it on a DEX first, then deposit what you hold.
 
 ## Options
 
 ### `provider`
 
-Provider to deposit for. Currently only `Filecoin` is supported.
+Provider to deposit for: `Filecoin` or `Fula`.
 
 ### `from`
 
-Wallet address holding the USDfc on Filecoin. Defaults to the signer's address (derived from the signing key).
+(Filecoin only.) Wallet address holding the USDfc on Filecoin. Defaults to the signer's address (derived from the signing key).
+
+### `chain`
+
+(Fula only.) Chain holding the `$FULA` to deposit: `eth` or `base`. When omitted, Omnipin auto-detects it by reading your `$FULA` balance on each chain and using the one where you hold it (the chain with the larger balance wins; ties go to `eth`). If you hold no `$FULA` on either chain, it defaults to `eth`. Pass `--chain` to force a specific chain.
+
+### `to`
+
+(Fula only.) Override the destination vault address. Defaults to Fula's payment vault. Useful if Fula rotates the vault.
+
+### `rpc-url`
+
+(Fula only.) Custom RPC for the deposit chain. Defaults to a public node for the selected chain.
 
 ### `verbose`
 
@@ -26,7 +48,12 @@ More verbose logs.
 
 ## Environment
 
-The signing key (hex, `0x`-prefixed) is used to sign the EIP-2612 permit and broadcast the deposit transaction. For `--provider=Filecoin`, Omnipin reads `OMNIPIN_FILECOIN_TOKEN` first — the same variable the `Filecoin` provider uses for `omnipin deploy` — so you only manage one key. If it is unset, Omnipin falls back to `OMNIPIN_PK`.
+The signing key (hex, `0x`-prefixed) signs and broadcasts the deposit transaction.
+
+For `--provider=Filecoin`, Omnipin reads `OMNIPIN_FILECOIN_TOKEN` first — the same variable the `Filecoin` provider uses for `omnipin deploy` — so you only manage one key. If it is unset, Omnipin falls back to `OMNIPIN_PK`.
+
+For `--provider=Fula`, the signing key is **separate** from the pinning API key: `OMNIPIN_FULA_TOKEN` holds the pinning-service JWT and is **never** used to sign. Omnipin reads `OMNIPIN_FULA_PK` first, falling back to `OMNIPIN_PK`.
 
 - `OMNIPIN_FILECOIN_TOKEN` — preferred for Filecoin; the Filecoin wallet's private key.
+- `OMNIPIN_FULA_PK` — preferred for Fula deposits; the wallet private key holding `$FULA`.
 - `OMNIPIN_PK` — generic fallback used when no provider-specific key is set.

--- a/docs/docs/ipfs.md
+++ b/docs/docs/ipfs.md
@@ -65,6 +65,15 @@ Omnipin supports a wide range of different IPFS providers.
       <td>❌</td>
     </tr>
     <tr>
+      <td><a href="#fula">Fula</a></td>
+      <td><a href="https://docs.fx.land/pinning-service">Docs</a></td>
+      <td>❌</td>
+      <td>✅ (500 MB free)</td>
+      <td>✅</td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
       <td><a href="#pinata">Pinata</a></td>
       <td><a href="https://docs.pinata.cloud/files/uploading-files">Docs</a></td>
       <td>❌</td>
@@ -207,7 +216,8 @@ OMNIPIN_SPEC_URL=https://pinning-service.example.com
 A few services provide a pinning service API:
 
 - [Filebase](https://filebase.com) (requires a paid plan)
-- [Fula Network](https://api.cloud.fx.land) (free up until 20GB)
+- [Fula](https://cloud.fx.land) — has first-class support, including CAR
+  upload. See [Fula](#fula) below.
 
 ## Filebase
 
@@ -296,6 +306,77 @@ omnipin bridge --provider=AIOZ \
 Supported source chains: `eth`, `bsc`. The command bridges AIOZ from the
 source chain to AIOZ Network, then forwards the funds to your AIOZ-Pin
 account. See [`omnipin bridge`](../cli/bridge) for details.
+
+## Fula
+
+- API env variables: `OMNIPIN_FULA_TOKEN`
+
+[Fula](https://cloud.fx.land) (Functionland Cloud) is a decentralized storage
+pinning service. Every account includes **500 MB free**, with pay-as-you-go
+FULA credits beyond that.
+
+Sign up at [cloud.fx.land](https://cloud.fx.land) (sign in with Google), open
+the **API Keys** page and click **Generate New Key**. The key is a JWT. Save
+it as:
+
+```sh
+OMNIPIN_FULA_TOKEN=<your_api_key>
+```
+
+Pinning by CID, listing, status and unpin use the standard
+[IPFS Pinning Service API](https://ipfs.github.io/pinning-services-api-spec).
+When Fula is the upload (first) provider, Omnipin uploads via the
+`POST /pins/import/car` CAR import endpoint, which preserves the local root CID
+exactly (no re-chunking or re-hashing).
+
+You can also import a DAG manually. Pin or add your data locally first, then
+export its DAG to a CAR and import it:
+
+```sh
+# Export the DAG of a local CID to a CAR file
+ipfs dag export bafybeib32tuqzs2wrc52rdt56cz73sqe3qu2deqdudssspnu4gbezmhig4 > data.car
+
+# Import the CAR into Fula
+curl -X POST "https://api.cloud.fx.land/pins/import/car" \
+  -H "Authorization: Bearer $OMNIPIN_FULA_TOKEN" \
+  -F "file=@data.car" \
+  -F "name=my-dataset"
+```
+
+See the
+[Fula Pinning Service API docs](https://docs.fx.land/pinning-service/pinning-api/endpoints.html)
+for more details.
+
+### Top-up
+
+Every account includes 500 MB free. Beyond that, storage is billed in `$FULA`
+credits (~3 FULA / GB / month). Fula has no chain of its own — `$FULA` is a
+plain ERC-20 deployed on **Ethereum**
+(`0x92217cCaEDBdbc54C76c15feA18823db1558fDc9`) and **Base**
+(`0x9e12735d77c72c5C3670636D428f2F3815d8A4cB`) — so topping up is a token
+transfer to Fula's payment vault, which credits your account.
+
+Acquire `$FULA` by swapping for it on a DEX, then deposit what you hold with
+the `deposit` command. The chain is auto-detected from where you hold `$FULA`
+(override with `--chain`):
+
+```sh
+# Deposit 10 $FULA (chain auto-detected from your balance)
+OMNIPIN_FULA_PK=0x... omnipin deposit --provider=Fula 10
+
+# Force a specific chain
+OMNIPIN_FULA_PK=0x... omnipin deposit --provider=Fula --chain=base 10
+```
+
+:::info
+The deposit signing key is **separate** from the pinning API key.
+`OMNIPIN_FULA_TOKEN` holds the pinning JWT and is never used to sign
+transactions; the wallet key comes from `OMNIPIN_FULA_PK` (or the generic
+`OMNIPIN_PK`).
+:::
+
+See [`omnipin deposit`](../cli/deposit) for all options (`--chain`, `--to`,
+`--rpc-url`).
 
 ## Pinata
 

--- a/src/actions/deposit.ts
+++ b/src/actions/deposit.ts
@@ -1,22 +1,37 @@
-import type { Address } from 'ox/Address'
+import { type Address, fromPublicKey } from 'ox/Address'
+import { getPublicKey } from 'ox/Secp256k1'
 import { MissingCLIArgsError, UnknownProviderError } from '../errors.js'
-import { resolveSignerKey } from '../utils/env.js'
+import { resolveFulaSignerKey, resolveSignerKey } from '../utils/env.js'
 import { depositFilecoinUsdfc } from '../utils/filecoin-deposit.js'
+import {
+  depositFula,
+  detectFulaChain,
+  type FulaChainKey,
+  isFulaChainKey,
+} from '../utils/fula-deposit.js'
 import { logger } from '../utils/logger.js'
 
 export type DepositActionArgs = Partial<{
   provider: string
   from: Address
+  chain: string
+  to: Address
+  'rpc-url': string
   verbose: boolean
 }>
 
 /**
  * Providers that have a separate deposit step on top of holding the
- * underlying token. Today only Filecoin has one (Filecoin Pay). AIOZ stores
- * the bill in native AIOZ on the AIOZ Network itself, so `bridge` is the
- * whole flow there.
+ * underlying token:
+ *
+ * - **Filecoin** — moves USDfc into Filecoin Pay.
+ * - **Fula** — transfers $FULA to Fula's payment vault (Fula has no chain of
+ *   its own; $FULA is an ERC-20 on Ethereum and Base).
+ *
+ * AIOZ stores the bill in native AIOZ on the AIOZ Network itself, so `bridge`
+ * is the whole flow there.
  */
-const SUPPORTED_PROVIDERS = new Set(['Filecoin'])
+const SUPPORTED_PROVIDERS = new Set(['Filecoin', 'Fula'])
 
 export const depositAction = async ({
   amount,
@@ -31,6 +46,51 @@ export const depositAction = async ({
   if (!provider) throw new MissingCLIArgsError(['provider'])
   if (!SUPPORTED_PROVIDERS.has(provider))
     throw new UnknownProviderError(provider)
+
+  if (provider === 'Fula') {
+    const pk = resolveFulaSignerKey()
+
+    let chain: FulaChainKey
+    if (options.chain) {
+      // Explicit override: validate it.
+      const requested = options.chain.toLowerCase()
+      if (!isFulaChainKey(requested))
+        throw new Error(
+          `Unsupported chain "${options.chain}" for Fula deposit. Supported: eth, base.`,
+        )
+      chain = requested
+    } else {
+      // Auto-detect: deposit from the chain where the signer holds $FULA.
+      const signer = fromPublicKey(getPublicKey({ privateKey: pk }))
+      const detected = await detectFulaChain({
+        owner: signer,
+        verbose: options.verbose,
+      })
+      if (detected) {
+        chain = detected
+        logger.info(`Using ${chain} (holds $FULA); override with --chain`)
+      } else {
+        chain = 'eth'
+        logger.info(
+          'No $FULA balance found on eth or base; defaulting to eth. Override with --chain.',
+        )
+      }
+    }
+
+    const result = await depositFula({
+      privateKey: pk,
+      amount,
+      chain,
+      to: options.to,
+      rpcUrl: options['rpc-url'],
+      verbose: options.verbose,
+    })
+
+    if (options.verbose) {
+      logger.text(JSON.stringify(result, null, 2))
+    }
+    return
+  }
 
   const pk = resolveSignerKey(provider)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -329,17 +329,34 @@ cli.command<[string]>(
     }),
   {
     description:
-      'Deposit already-held tokens into a provider payment contract (Filecoin: USDfc → Filecoin Pay).',
+      'Deposit already-held tokens into a provider payment contract (Filecoin: USDfc → Filecoin Pay; Fula: $FULA → Fula vault).',
     options: [
       {
         name: 'provider',
-        description: 'Provider to deposit for (Filecoin)',
+        description: 'Provider to deposit for (Filecoin or Fula)',
         type: 'string',
       },
       {
         name: 'from',
         description:
-          'Wallet address holding the tokens. Defaults to the signer address.',
+          'Wallet address holding the tokens. Defaults to the signer address. (Filecoin only.)',
+        type: 'string',
+      },
+      {
+        name: 'chain',
+        description:
+          'Chain holding the $FULA to deposit (eth or base). Fula only; auto-detected from your $FULA balance when omitted.',
+        type: 'string',
+      },
+      {
+        name: 'to',
+        description:
+          'Override the destination vault address. Fula only; defaults to the Fula payment vault.',
+        type: 'string',
+      },
+      {
+        name: 'rpc-url',
+        description: 'Custom RPC for the deposit chain. Fula only.',
         type: 'string',
       },
       {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,11 @@ import {
 } from './providers/ipfs/filebase.js'
 import { uploadToFilecoin } from './providers/ipfs/filecoin.js'
 import {
+  statusOnFula,
+  unpinOnFula,
+  uploadOnFula,
+} from './providers/ipfs/fula.js'
+import {
   statusOnIpfsNinja,
   unpinOnIpfsNinja,
   uploadOnIpfsNinja,
@@ -166,6 +171,14 @@ export const PROVIDERS: Record<
     name: 'AIOZ',
     upload: pinOnAioz,
     supported: 'pin',
+    protocol: 'ipfs',
+  },
+  FULA_TOKEN: {
+    name: 'Fula',
+    upload: uploadOnFula,
+    status: statusOnFula,
+    unpin: unpinOnFula,
+    supported: 'both',
     protocol: 'ipfs',
   },
 }

--- a/src/providers/ipfs/fula.ts
+++ b/src/providers/ipfs/fula.ts
@@ -1,0 +1,80 @@
+import { DeployError } from '../../errors.js'
+import type {
+  StatusFunction,
+  UnpinFunction,
+  UploadFunction,
+} from '../../types.js'
+import { logger } from '../../utils/logger.js'
+import { specPin, specStatus, specUnpin } from './spec.js'
+
+const providerName = 'Fula'
+
+// Fula Land (Functionland) Cloud pinning service.
+// https://docs.fx.land/pinning-service/ipfs-pinning-service-api
+//
+// Pin-by-CID, list, get and delete are the standard IPFS Pinning Service API
+// (handled by the `spec` helpers). Uploading data that exists only on the
+// client is done via the `POST /pins/import/car` vendor extension, which
+// imports a CAR and pins its single root — preserving the local root CID
+// exactly (no re-chunking or re-hashing).
+const baseURL = 'https://api.cloud.fx.land'
+
+const errorMessage = (json: {
+  error?: { details?: string; reason?: string }
+  message?: string
+}) =>
+  json.error?.details || json.error?.reason || json.message || 'Unknown error'
+
+export const uploadOnFula: UploadFunction = async ({
+  bytes,
+  name,
+  token,
+  verbose,
+  first,
+  cid,
+}) => {
+  if (first) {
+    const fd = new FormData()
+
+    fd.append(
+      'file',
+      new Blob([bytes], { type: 'application/vnd.ipld.car' }),
+      `${name}.car`,
+    )
+
+    if (name) fd.append('name', name)
+
+    const res = await fetch(`${baseURL}/pins/import/car`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      body: fd,
+    })
+
+    if (verbose) logger.request('POST', res.url, res.status)
+
+    const json = await res.json()
+
+    if (!res.ok) throw new DeployError(providerName, errorMessage(json))
+
+    return { cid: json.pin?.cid ?? cid, status: json.status }
+  }
+
+  // Pin an existing CID via the standard Pinning Service API.
+  return specPin({
+    first,
+    cid,
+    name,
+    token,
+    verbose,
+    providerName,
+    baseURL,
+  })
+}
+
+export const statusOnFula: StatusFunction = (args) =>
+  specStatus({ ...args, baseURL })
+
+export const unpinOnFula: UnpinFunction = (args) =>
+  specUnpin({ baseURL, providerName })(args)

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -61,3 +61,23 @@ export const resolveSignerKey = (provider: string): Hex => {
 
   throw new MissingKeyError(findEnvVarProviderName(provider))
 }
+
+/**
+ * Resolve the signing key for Fula's onchain `deposit`.
+ *
+ * Unlike Filecoin (whose `OMNIPIN_FILECOIN_TOKEN` *is* a private key), Fula's
+ * `OMNIPIN_FULA_TOKEN` holds the pinning-service JWT, not a wallet key — so it
+ * must never be used to sign. The wallet key is read from the dedicated
+ * `OMNIPIN_FULA_PK`, falling back to the generic `OMNIPIN_PK`.
+ *
+ * @throws {MissingKeyError} If neither `OMNIPIN_FULA_PK` nor `OMNIPIN_PK` is set.
+ */
+export const resolveFulaSignerKey = (): Hex => {
+  const fulaPk = process.env.OMNIPIN_FULA_PK as Hex | undefined
+  if (fulaPk) return fulaPk
+
+  const pk = process.env.OMNIPIN_PK as Hex | undefined
+  if (pk) return pk
+
+  throw new MissingKeyError('FULA_PK')
+}

--- a/src/utils/filecoin-bridge.ts
+++ b/src/utils/filecoin-bridge.ts
@@ -284,7 +284,7 @@ export const resolveSourceToken = ({
 }
 
 /** Read on-chain decimals for an ERC-20, or return 18 for the native sentinel. */
-const fetchTokenDecimals = async ({
+export const fetchTokenDecimals = async ({
   provider,
   token,
 }: {

--- a/src/utils/fula-deposit.ts
+++ b/src/utils/fula-deposit.ts
@@ -1,0 +1,220 @@
+import { encodeData } from 'ox/AbiFunction'
+import { type Address, fromPublicKey } from 'ox/Address'
+import type { Hex } from 'ox/Hex'
+import * as Provider from 'ox/Provider'
+import { fromHttp } from 'ox/RpcTransport'
+import { getPublicKey } from 'ox/Secp256k1'
+import * as Value from 'ox/Value'
+import { fetchSourceBalance } from './filecoin-bridge.js'
+import { logger } from './logger.js'
+import { sendTransaction, waitForTransaction } from './tx.js'
+
+/**
+ * Fula (Functionland) deposit.
+ *
+ * Fula has no chain of its own — $FULA is a plain ERC-20 deployed on Ethereum
+ * and Base — so "deposit" is simply an ERC-20 `transfer` of $FULA to Fula's
+ * payment vault. The credited balance is then spent down by the pinning
+ * service (3 FULA / GB / month). To acquire $FULA from another token first,
+ * swap on a DEX, then run this command with the $FULA you hold.
+ */
+
+/** Chains where $FULA is deployed and the deposit vault is reachable. */
+export type FulaChainKey = 'eth' | 'base'
+
+type FulaChainConfig = {
+  id: 1 | 8453
+  name: string
+  rpc: string
+  explorer: string
+  /** $FULA (Functionland Fula) ERC-20, 18 decimals. */
+  token: Address
+}
+
+export const FULA_CHAINS: Record<FulaChainKey, FulaChainConfig> = {
+  eth: {
+    id: 1,
+    name: 'Ethereum',
+    rpc: 'https://ethereum-rpc.publicnode.com',
+    explorer: 'https://etherscan.io',
+    token: '0x92217cCaEDBdbc54C76c15feA18823db1558fDc9',
+  },
+  base: {
+    id: 8453,
+    name: 'Base',
+    rpc: 'https://base-rpc.publicnode.com',
+    explorer: 'https://basescan.org',
+    token: '0x9e12735d77c72c5C3670636D428f2F3815d8A4cB',
+  },
+}
+
+export const isFulaChainKey = (v: string | undefined): v is FulaChainKey =>
+  typeof v === 'string' && v in FULA_CHAINS
+
+/**
+ * Fula's deposit vault. $FULA sent here is credited to the sender's Fula
+ * account. The same EOA is used across the supported chains; override with
+ * `--to` if Fula rotates it.
+ */
+export const FULA_VAULT_ADDRESS: Address =
+  '0x83dF763874934Cc72C309dA5566eA2AFB6eE4f4e'
+
+/** $FULA has 18 decimals on every chain it is deployed to. */
+const FULA_DECIMALS = 18
+
+const erc20Transfer = {
+  name: 'transfer',
+  type: 'function',
+  stateMutability: 'nonpayable',
+  inputs: [
+    { name: 'to', type: 'address' },
+    { name: 'amount', type: 'uint256' },
+  ],
+  outputs: [{ type: 'bool' }],
+} as const
+
+export type FulaDepositResult = {
+  /** Source-chain tx hash of the $FULA transfer to the vault. */
+  depositTxHash: Hex
+  /** Amount deposited, in $FULA atomic units (18 decimals). */
+  depositedAmount: bigint
+  /** Chain the deposit was made on. */
+  chain: FulaChainKey
+  /** Vault the $FULA was sent to. */
+  vault: Address
+}
+
+/** Order chains are probed/reported in, and the tiebreaker fallback (eth first). */
+const FULA_CHAIN_ORDER: FulaChainKey[] = ['eth', 'base']
+
+/**
+ * Auto-detect which chain to deposit from when `--chain` is omitted.
+ *
+ * The vault is the same EOA on every chain, so there is no on-chain "home
+ * chain" marker. Instead we pick the chain where the deposit can actually
+ * succeed: the one where `owner` holds the most $FULA. Each probe is a single
+ * `balanceOf` call, run in parallel, and tolerant of a chain's RPC being down.
+ *
+ * @returns The chain with the largest $FULA balance for `owner`, or
+ *   `undefined` if `owner` holds no $FULA on any supported chain (the caller
+ *   then falls back to the default).
+ */
+export const detectFulaChain = async ({
+  owner,
+  verbose,
+}: {
+  owner: Address
+  verbose?: boolean
+}): Promise<FulaChainKey | undefined> => {
+  const balances = await Promise.all(
+    FULA_CHAIN_ORDER.map(async (chain) => {
+      const cfg = FULA_CHAINS[chain]
+      try {
+        const provider = Provider.from(fromHttp(cfg.rpc))
+        const balance = await fetchSourceBalance({
+          provider,
+          token: cfg.token,
+          owner,
+        })
+        return { chain, balance }
+      } catch (e) {
+        if (verbose)
+          logger.warn(`Could not read FULA balance on ${cfg.name}: ${e}`)
+        return { chain, balance: 0n }
+      }
+    }),
+  )
+
+  // Highest balance wins; FULA_CHAIN_ORDER (eth first) breaks ties.
+  const best = balances.reduce((a, b) => (b.balance > a.balance ? b : a))
+  if (best.balance <= 0n) return undefined
+
+  if (verbose) {
+    const summary = balances
+      .map((b) => `${FULA_CHAINS[b.chain].name}=${Value.format(b.balance, 18)}`)
+      .join(', ')
+    logger.info(`Detected FULA balances: ${summary} → using ${best.chain}`)
+  }
+  return best.chain
+}
+
+/**
+ * Transfer already-held $FULA to Fula's payment vault.
+ *
+ * @param amount Whole $FULA to deposit (e.g. `'10'` ⇒ 10 FULA). 18 decimals.
+ * @param chain  Chain the $FULA is held on (`eth` or `base`).
+ * @param to     Override the vault address (defaults to {@link FULA_VAULT_ADDRESS}).
+ */
+export const depositFula = async ({
+  privateKey,
+  amount,
+  chain,
+  to,
+  rpcUrl,
+  verbose,
+}: {
+  privateKey: Hex
+  amount: string
+  chain: FulaChainKey
+  to?: Address
+  rpcUrl?: string
+  verbose?: boolean
+}): Promise<FulaDepositResult> => {
+  const chainConfig = FULA_CHAINS[chain]
+  const vault = (to ?? FULA_VAULT_ADDRESS) as Address
+
+  const signer = fromPublicKey(getPublicKey({ privateKey }))
+
+  let amountAtomic: bigint
+  try {
+    amountAtomic = Value.from(amount, FULA_DECIMALS)
+  } catch {
+    throw new Error(`Invalid amount: ${amount}`)
+  }
+  if (amountAtomic <= 0n) throw new Error(`Amount must be positive: ${amount}`)
+
+  const transport = fromHttp(rpcUrl ?? chainConfig.rpc)
+  const provider = Provider.from(transport)
+
+  logger.start(
+    `Deposit ${Value.format(amountAtomic, FULA_DECIMALS)} FULA to Fula vault on ${chainConfig.name}`,
+  )
+
+  // Fail fast on insufficient balance instead of letting transfer() revert
+  // after gas is already spent.
+  const balance = await fetchSourceBalance({
+    provider,
+    token: chainConfig.token,
+    owner: signer,
+  })
+  if (balance < amountAtomic) {
+    throw new Error(
+      `Insufficient FULA on ${chainConfig.name} for ${signer}: have ${Value.format(
+        balance,
+        FULA_DECIMALS,
+      )}, need ${Value.format(amountAtomic, FULA_DECIMALS)}`,
+    )
+  }
+
+  if (verbose) logger.info(`Sending FULA to vault ${vault}`)
+
+  const depositTxHash = (await sendTransaction({
+    provider,
+    chainId: chainConfig.id,
+    privateKey,
+    to: chainConfig.token,
+    data: encodeData(erc20Transfer, [vault, amountAtomic]),
+    from: signer,
+  })) as Hex
+
+  logger.info(`Deposit tx: ${chainConfig.explorer}/tx/${depositTxHash}`)
+  await waitForTransaction(provider, depositTxHash)
+  logger.success('Deposit confirmed')
+
+  return {
+    depositTxHash,
+    depositedAmount: amountAtomic,
+    chain,
+    vault,
+  }
+}

--- a/test/providers/fula-deposit.test.ts
+++ b/test/providers/fula-deposit.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'bun:test'
+
+import {
+  depositFula,
+  detectFulaChain,
+  FULA_CHAINS,
+  FULA_VAULT_ADDRESS,
+  isFulaChainKey,
+} from '../../src/utils/fula-deposit.js'
+
+// A throwaway, well-known test private key (Hardhat account #0). Used only to
+// derive a signer address for amount-validation tests; no transaction is sent.
+const TEST_PK =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+
+describe('Fula deposit', () => {
+  describe('config', () => {
+    it('exposes FULA ERC-20 addresses on eth and base', () => {
+      expect(FULA_CHAINS.eth.id).toBe(1)
+      expect(FULA_CHAINS.eth.token).toBe(
+        '0x92217cCaEDBdbc54C76c15feA18823db1558fDc9',
+      )
+      expect(FULA_CHAINS.base.id).toBe(8453)
+      expect(FULA_CHAINS.base.token).toBe(
+        '0x9e12735d77c72c5C3670636D428f2F3815d8A4cB',
+      )
+    })
+
+    it('points at the Fula payment vault by default', () => {
+      expect(FULA_VAULT_ADDRESS).toBe(
+        '0x83dF763874934Cc72C309dA5566eA2AFB6eE4f4e',
+      )
+    })
+
+    it('guards chain keys', () => {
+      expect(isFulaChainKey('eth')).toBe(true)
+      expect(isFulaChainKey('base')).toBe(true)
+      expect(isFulaChainKey('polygon')).toBe(false)
+      expect(isFulaChainKey(undefined)).toBe(false)
+    })
+  })
+
+  describe('amount validation', () => {
+    it('rejects a non-numeric amount before any network call', async () => {
+      await expect(
+        depositFula({
+          privateKey: TEST_PK,
+          amount: 'abc',
+          chain: 'eth',
+        }),
+      ).rejects.toThrow('Invalid amount: abc')
+    })
+
+    it('rejects a zero amount', async () => {
+      await expect(
+        depositFula({
+          privateKey: TEST_PK,
+          amount: '0',
+          chain: 'base',
+        }),
+      ).rejects.toThrow('Amount must be positive')
+    })
+
+    it('rejects a negative amount', async () => {
+      await expect(
+        depositFula({
+          privateKey: TEST_PK,
+          amount: '-5',
+          chain: 'eth',
+        }),
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('chain auto-detection', () => {
+    it(
+      'detects the chain where the owner holds $FULA (vault holds it on Base)',
+      async () => {
+        // The Fula vault holds $FULA on Base and none on Ethereum, so it is a
+        // stable, live fixture for the "highest balance wins" heuristic.
+        const chain = await detectFulaChain({ owner: FULA_VAULT_ADDRESS })
+        expect(chain).toBe('base')
+      },
+      { timeout: 20_000 },
+    )
+
+    it(
+      'returns undefined when the owner holds no $FULA on any chain',
+      async () => {
+        const chain = await detectFulaChain({
+          owner: '0x000000000000000000000000000000000000dEaD',
+        })
+        expect(chain).toBeUndefined()
+      },
+      { timeout: 20_000 },
+    )
+  })
+})

--- a/test/providers/fula.test.ts
+++ b/test/providers/fula.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'bun:test'
+
+import { PROVIDERS } from '../../src/constants.js'
+import { packCAR, walk } from '../../src/index.js'
+import {
+  statusOnFula,
+  unpinOnFula,
+  uploadOnFula,
+} from '../../src/providers/ipfs/fula.js'
+
+const { upload, status, unpin } = PROVIDERS.FULA_TOKEN
+const token = Bun.env.OMNIPIN_FULA_TOKEN!
+const hasToken = Boolean(token)
+
+describe('Fula', () => {
+  // CID uploaded by the `upload` test and reused by `pin` / `unpin`. The
+  // `unpin` test removes it at the end, so the suite cleans up after itself.
+  let uploadedCid = ''
+
+  it('is registered in PROVIDERS with upload, status, and unpin', () => {
+    expect(upload).toBe(uploadOnFula)
+    expect(status).toBe(statusOnFula)
+    expect(unpin).toBe(unpinOnFula)
+    expect(PROVIDERS.FULA_TOKEN.supported).toBe('both')
+    expect(PROVIDERS.FULA_TOKEN.protocol).toBe('ipfs')
+    expect(PROVIDERS.FULA_TOKEN.name).toBe('Fula')
+  })
+
+  describe('status', () => {
+    it.skipIf(!hasToken)(
+      'returns "not pinned" for an unknown CID',
+      async () => {
+        const result = await statusOnFula({
+          cid: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdq',
+          auth: { token },
+        })
+        expect(result.pin).toBe('not pinned')
+      },
+      { timeout: 15_000 },
+    )
+  })
+
+  describe('upload', () => {
+    it.skipIf(!hasToken)(
+      'imports a CAR and preserves the root CID',
+      async () => {
+        const [size, files] = await walk('./dist', false)
+        const car = await packCAR(files, 'test')
+
+        const { cid } = await uploadOnFula({
+          token,
+          name: `omnipin-test-${Date.now()}`,
+          first: true,
+          bytes: car.bytes,
+          cid: car.rootCID.toString(),
+          size,
+        })
+
+        expect(cid).toBe(car.rootCID.toString())
+        uploadedCid = cid
+      },
+      { timeout: 60_000 },
+    )
+  })
+
+  describe('pin', () => {
+    it.skipIf(!hasToken)(
+      're-pins the uploaded CID via the standard /pins endpoint',
+      async () => {
+        expect(uploadedCid).not.toBe('')
+
+        const result = await uploadOnFula({
+          token,
+          cid: uploadedCid,
+          name: 'omnipin pin test',
+          first: false,
+          bytes: new Uint8Array(),
+          size: 0,
+        })
+
+        expect(result.cid).toBe(uploadedCid)
+      },
+      { timeout: 30_000 },
+    )
+  })
+
+  describe('unpin', () => {
+    it.skipIf(!hasToken)(
+      'unpins the uploaded CID, cleaning up the upload',
+      async () => {
+        expect(uploadedCid).not.toBe('')
+
+        const result = await unpinOnFula({ token, cid: uploadedCid })
+        expect(result.success).toBe(true)
+        expect(result.cid).toBe(uploadedCid)
+      },
+      { timeout: 15_000 },
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Adds [Fula](https://cloud.fx.land) (Functionland Cloud) as an IPFS provider, plus a `deposit` command to top up `$FULA` credits.

### Provider (`src/providers/ipfs/fula.ts`)
- **Upload**: when Fula is the first/upload provider, uploads via the `POST /pins/import/car` CAR import endpoint, which preserves the local root CID exactly (no re-chunking/re-hashing).
- **Pin / status / unpin**: the standard [IPFS Pinning Service API](https://ipfs.github.io/pinning-services-api-spec) at `https://api.cloud.fx.land` (reuses the existing `spec` helpers).
- Registered as `FULA_TOKEN` (`supported: 'both'`, `protocol: 'ipfs'`), configured via `OMNIPIN_FULA_TOKEN` (the pinning JWT from cloud.fx.land).

### Deposit (`omnipin deposit --provider=Fula <amount>`)
Fula has no chain of its own — `$FULA` is a plain ERC-20 on **Ethereum** (`0x9221…fDc9`) and **Base** (`0x9e12…A4cB`), confirmed via `cast` (Functionland Fula, 18 decimals). The payment vault `0x83dF…4f4e` is a plain EOA (no contract code; verified via `cast code` + Sourcify), so a deposit is just an ERC-20 `transfer` that credits your account.

- **Chain auto-detection**: when `--chain` is omitted, reads your `$FULA` balance on eth + base and deposits from the chain where you hold it (ties → `eth`; none → defaults to `eth`). Override with `--chain=eth|base`.
- `--to` overrides the vault; `--rpc-url` overrides the RPC.
- **Key separation**: signing key is `OMNIPIN_FULA_PK` → `OMNIPIN_PK`. `OMNIPIN_FULA_TOKEN` is the pinning JWT and is **never** used to sign.

### Docs
- `docs/docs/ipfs.md`: new Fula section (CAR import + manual `ipfs dag export` example) and a Top-up section; added to the provider table.
- `docs/cli/deposit.md`: documents `--provider=Fula`, `--chain` (incl. auto-detection), `--to`, `--rpc-url`, and the key model.

## Testing
- `test/providers/fula.test.ts` — full lifecycle against the live API (status → CAR upload → pin → unpin), token-gated with `it.skipIf`. All pass with a real token.
- `test/providers/fula-deposit.test.ts` — config/validation plus live chain-detection (the vault is a stable Base-holding fixture). Uses the public Hardhat test key for address derivation only; no transactions are sent.

```
13 pass, 0 fail
```

- Types: clean (the only `tsc` errors are pre-existing in `filecoin*.ts`).
- Lint: clean (`bun run check`).

## Notes
- `fetchTokenDecimals` in `filecoin-bridge.ts` was exported (one-line change) for reuse; no behavior change.
- The deposit detection is balance-based — if you hold `$FULA` on both chains it picks the larger balance, and `--chain` forces the choice.
