### PR TITLE
deps: bump foc to 0.0.18 for FWSS v1.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.7",
         "@ipld/car": "^5.4.2",
-        "@omnipin/foc": "npm:@jsr/omnipin__foc@0.0.15",
+        "@omnipin/foc": "npm:@jsr/omnipin__foc@0.0.18",
         "@rslib/core": "^0.20.0",
         "@size-limit/file": "^12.0.1",
         "@stauro/filebase-upload": "npm:@jsr/stauro__filebase-upload",
@@ -110,7 +110,7 @@
 
     "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
-    "@omnipin/foc": ["@jsr/omnipin__foc@0.0.15", "https://npm.jsr.io/~/11/@jsr/omnipin__foc/0.0.15.tgz", { "dependencies": { "@noble/hashes": "^2.0.1", "multiformats": "^13.4.2", "ox": "^0.14.8", "varint": "^6.0.0" } }, "sha512-gkmUrvoWXhQ+BN7PrX80esQST2adikjsNDLelF8LhcdDLXgkB+hboGrszTEKzzBGDi5epDtU11b/HIR00EgseQ=="],
+    "@omnipin/foc": ["@jsr/omnipin__foc@0.0.18", "https://npm.jsr.io/~/11/@jsr/omnipin__foc/0.0.18.tgz", { "dependencies": { "@noble/hashes": "^2.0.1", "multiformats": "^13.4.2", "ox": "^0.14.8", "varint": "^6.0.0" } }, "sha512-4t2tYmXdRghbAIt8rGN3qVdCddXg6qSxiLCyrJzqhU6tgYsmQFTJRDSn7IkQH1JoMA8umz1BOR7AeOmmLAzZ3g=="],
 
     "@rsbuild/core": ["@rsbuild/core@2.0.0-rc.0", "", { "dependencies": { "@rspack/core": "2.0.0-rc.0", "@swc/helpers": "^0.5.20" }, "peerDependencies": { "core-js": ">= 3.0.0" }, "optionalPeers": ["core-js"], "bin": { "rsbuild": "bin/rsbuild.js" } }, "sha512-XutQgxd71RyH9jT0x+/F0DiGqk2Q5oofZuzNZFEkSayjO1UG+uVLhK90zB4hW43qRHqGEqcWlVaNPSQ8rHLk6A=="],
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.7",
 		"@ipld/car": "^5.4.2",
-		"@omnipin/foc": "npm:@jsr/omnipin__foc@0.0.15",
+		"@omnipin/foc": "npm:@jsr/omnipin__foc@0.0.18",
 		"@rslib/core": "^0.20.0",
 		"@size-limit/file": "^12.0.1",
 		"@stauro/filebase-upload": "npm:@jsr/stauro__filebase-upload",

--- a/src/utils/filecoin-bridge.ts
+++ b/src/utils/filecoin-bridge.ts
@@ -1,11 +1,9 @@
 import {
-  DEFAULT_MINIMUM_NEW_DATASET_LOCKUP,
+  DEFAULT_NEW_DATASET_FIXED_FUNDS,
   filecoinMainnet,
   filProvider,
-  LOCKUP_PERIOD,
-  USDFC_SYBIL_FEE,
 } from '@omnipin/foc/utils'
-import { getServicePricing } from '@omnipin/foc/warm-storage'
+import { getPriceList } from '@omnipin/foc/warm-storage'
 import { decodeResult, encodeData } from 'ox/AbiFunction'
 import { type Address, fromPublicKey } from 'ox/Address'
 import { fromNumber, type Hex, toBigInt } from 'ox/Hex'
@@ -593,31 +591,36 @@ const withFinalityCountdown = async <T>(
 }
 
 /**
- * Filecoin Pay / FWSS minimum deposit for a new dataset:
- * `(minimumPricePerMonth * LOCKUP_PERIOD) / epochsPerMonth + sybil fee`.
- * Mirrors `FilecoinWarmStorageService.validatePayerOperatorApprovalAndFunds`.
- * Bridging less USDfc than this yields funds that can't pay for storage.
+ * Filecoin Pay / FWSS minimum deposit for a new dataset.
+ *
+ * As of FWSS v1.3.0 the minimum-rate floor and sybil fee are gone. Creating a
+ * dataset instead locks a fixed lifecycle reserve on the PDP rail plus a
+ * one-time creation fee, so the up-front floor is simply
+ * `lifecycleReserveTarget + createDataSetFee` (the `lockups`/`fees` from the
+ * on-chain price list). Bridging less USDfc than this yields funds that can't
+ * cover dataset creation.
+ *
+ * @see https://github.com/FilOzone/filecoin-services/releases/tag/v1.3.0
  */
 export const computeFwssFloor = (
-  minimumPricePerMonth: bigint,
-  epochsPerMonth: bigint,
-): bigint =>
-  (minimumPricePerMonth * LOCKUP_PERIOD) / epochsPerMonth + USDFC_SYBIL_FEE
+  lifecycleReserveTarget: bigint,
+  createDataSetFee: bigint,
+): bigint => lifecycleReserveTarget + createDataSetFee
 
 /**
- * Live FWSS minimum deposit on Filecoin mainnet (the owner can raise the
- * floor up to 0.24 USDfc/mo). Falls back to the package default (~0.16 USDfc)
- * if the on-chain pricing read fails.
+ * Live FWSS minimum deposit on Filecoin mainnet, read from the v1.3.0 price
+ * list. Falls back to the package default (~0.125 USDfc) if the on-chain read
+ * fails.
  */
 const fwssMinimumDeposit = async (): Promise<bigint> => {
   try {
-    const pricing = await getServicePricing({ chain: filecoinMainnet })
+    const { lockups, fees } = await getPriceList({ chain: filecoinMainnet })
     return computeFwssFloor(
-      pricing.minimumPricePerMonth,
-      pricing.epochsPerMonth,
+      lockups.lifecycleReserveTarget,
+      fees.createDataSetFee,
     )
   } catch {
-    return DEFAULT_MINIMUM_NEW_DATASET_LOCKUP
+    return DEFAULT_NEW_DATASET_FIXED_FUNDS
   }
 }
 

--- a/test/utils/filecoin-bridge.test.ts
+++ b/test/utils/filecoin-bridge.test.ts
@@ -338,20 +338,20 @@ describe('fetchSourceBalance', () => {
 })
 
 describe('computeFwssFloor', () => {
-  // FWSS minimum deposit = minPricePerMonth * LOCKUP_PERIOD / epochsPerMonth
-  // + USDFC_SYBIL_FEE (0.1). At the default 30-day lockup, LOCKUP_PERIOD ==
-  // epochsPerMonth, so the lockup term reduces to minPricePerMonth.
-  it('equals the FWSS new-dataset minimum at initial pricing (0.16 USDfc)', () => {
-    // 0.06 USDfc/mo floor + 0.1 USDfc sybil fee = 0.16 USDfc.
-    expect(computeFwssFloor(60_000_000_000_000_000n, 86_400n)).toBe(
-      160_000_000_000_000_000n,
-    )
+  // FWSS v1.3.0 new-dataset minimum = lifecycleReserveTarget + createDataSetFee
+  // (the fixed funds the contract locks on the PDP rail at creation). The
+  // minimum-rate floor and sybil fee were removed in v1.3.0.
+  it('equals the FWSS new-dataset fixed funds at default pricing (0.125 USDfc)', () => {
+    // 0.10 USDfc lifecycle reserve + 0.025 USDfc create fee = 0.125 USDfc.
+    expect(
+      computeFwssFloor(100_000_000_000_000_000n, 25_000_000_000_000_000n),
+    ).toBe(125_000_000_000_000_000n)
   })
 
-  it('scales with a raised minimum monthly price', () => {
-    // 0.12 USDfc/mo + 0.1 sybil = 0.22 USDfc.
-    expect(computeFwssFloor(120_000_000_000_000_000n, 86_400n)).toBe(
-      220_000_000_000_000_000n,
-    )
+  it('tracks a raised lifecycle reserve or creation fee', () => {
+    // 0.20 USDfc reserve + 0.05 USDfc create fee = 0.25 USDfc.
+    expect(
+      computeFwssFloor(200_000_000_000_000_000n, 50_000_000_000_000_000n),
+    ).toBe(250_000_000_000_000_000n)
   })
 })


### PR DESCRIPTION
Migrate the Filecoin bridge off the removed getServicePrice struct (minimum-rate floor + sybil fee) to the v1.3.0 getPriceList model, where a new dataset's up-front floor is the fixed lifecycleReserveTarget + createDataSetFee.

- Repoint @omnipin/foc alias to npm:@jsr/omnipin__foc@0.0.18
- filecoin-bridge: getServicePricing -> getPriceList; computeFwssFloor now sums lifecycleReserveTarget + createDataSetFee; fall back to DEFAULT_NEW_DATASET_FIXED_FUNDS
- Update computeFwssFloor tests to the v1.3.0 fixed-funds model