### PR TITLE
feat(swarm): add experimental Hoverfly provider via daemon socket

### DIFF
--- a/docs/docs/swarm.md
+++ b/docs/docs/swarm.md
@@ -37,7 +37,13 @@ hoverfly daemon \
   --peerlist peers.json
 ```
 
-The repo ships a curated `peers.seed.json`; copy it to `peers.json` for a fast cold start (`cp peers.seed.json peers.json`). On a cold or stale peerlist, add `--discover-rounds 3`.
+Always fetch a fresh peerlist from the GitHub CDN — the release-bundled `peers.seed.json` goes stale:
+
+```sh
+curl -fsSL -o peers.json https://raw.githubusercontent.com/omnipin/hoverfly/main/peers.seed.json
+```
+
+On a cold peerlist, add `--discover-rounds 3`.
 
 ### Running the deployment
 

--- a/docs/docs/swarm.md
+++ b/docs/docs/swarm.md
@@ -1,6 +1,6 @@
 # Swarm
 
-Omnipin supports uploading on the [Swarm](https://ethswarm.org) decentralized network via [Swarmy](https://swarmy.cloud) and a Bee node.
+Omnipin supports uploading on the [Swarm](https://ethswarm.org) decentralized network via [Swarmy](https://swarmy.cloud), a Bee node, or the [Hoverfly](https://github.com/omnipin/hoverfly) light client.
 
 ## Swarmy
 
@@ -32,6 +32,63 @@ Then run the deployment command:
 ```sh
 omnipin deploy --ens omnipin.eth --safe eth:0x...
 ```
+
+## Hoverfly
+
+- API token env variables: `OMNIPIN_HOVERFLY_TOKEN`, `OMNIPIN_HOVERFLY_KEY`
+- Supported methods: Upload
+
+[Hoverfly](https://github.com/omnipin/hoverfly) is a minimal Swarm light client. Omnipin uploads through a locally-running `hoverfly daemon` over its UNIX socket — no Bee node and no remote API. The daemon holds a warm libp2p session pool, so each deploy is a single fast push instead of paying the cold connection-fill cost in-process.
+
+### Setup
+
+Install Hoverfly:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/omnipin/hoverfly/main/install.sh | sh
+```
+
+Generate a signer key, fund it with xDAI + BZZ on Gnosis (see the [Hoverfly README](https://github.com/omnipin/hoverfly#setup)), then buy a postage batch and generate an overlay nonce directly with the CLI.
+
+Buy a postage stamp batch and generate an overlay nonce:
+
+```sh
+hoverfly batch create --key 0xYOUR_KEY --size 200MB --duration 30d
+hoverfly vanity-overlay --key 0xYOUR_KEY --peerlist peers.json --output overlay-nonce
+```
+
+### Running the daemon
+
+Start the daemon and leave it running. It picks up `peers.json` and the overlay nonce from the paths you pass, and keeps a warm session pool ready for uploads:
+
+```sh
+hoverfly daemon \
+  --socket /tmp/hoverfly.sock \
+  --pool-size 256 \
+  --identity 0xYOUR_KEY \
+  --nonce-file overlay-nonce \
+  --peerlist peers.json
+```
+
+The repo ships a curated `peers.seed.json`; copy it to `peers.json` for a fast cold start (`cp peers.seed.json peers.json`). On a cold or stale peerlist, add `--discover-rounds 3` so the eager pool fill has enough fresh peers to dial; a warm peerlist needs no discovery. The daemon persists reachability observations on shutdown, so subsequent starts are warmer.
+
+### Running the deployment
+
+Set the postage batch ID and signer key in the environment:
+
+```sh
+OMNIPIN_HOVERFLY_TOKEN=0xf078...1afc # postage batch ID
+OMNIPIN_HOVERFLY_KEY=da25...0a44
+# OMNIPIN_HOVERFLY_SOCKET=/tmp/hoverfly.sock   # optional, this is the default
+```
+
+Then run the deployment command:
+
+```sh
+omnipin deploy
+```
+
+Omnipin reads the batch depth on-chain automatically; override it with `OMNIPIN_HOVERFLY_DEPTH` to skip the lookup. Other optional knobs: `OMNIPIN_HOVERFLY_RPC_URL` (Gnosis RPC for the depth lookup), `OMNIPIN_HOVERFLY_CONCURRENCY` (session fan-out, defaults to 256 — raise toward `512` to push throughput on a large pool), and `OMNIPIN_HOVERFLY_RETRIES` (per-chunk retries, defaults to 60).
 
 ## Bee node
 

--- a/docs/docs/swarm.md
+++ b/docs/docs/swarm.md
@@ -1,6 +1,61 @@
 # Swarm
 
-Omnipin supports uploading on the [Swarm](https://ethswarm.org) decentralized network via [Swarmy](https://swarmy.cloud), a Bee node, or the [Hoverfly](https://github.com/omnipin/hoverfly) light client.
+Omnipin supports uploading on the [Swarm](https://ethswarm.org) decentralized network via the [Hoverfly](https://github.com/omnipin/hoverfly) light client, [Swarmy](https://swarmy.cloud), or a Bee node.
+
+## Hoverfly
+
+- API token env variables: `OMNIPIN_HOVERFLY_TOKEN`, `OMNIPIN_HOVERFLY_KEY`
+- Supported methods: Upload
+
+[Hoverfly](https://github.com/omnipin/hoverfly) is a Swarm light client that requires no Bee node and no remote server — it runs entirely on your machine and works in CI.
+
+### Setup
+
+Install Hoverfly:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/omnipin/hoverfly/main/install.sh | sh
+```
+
+Generate a signer key, fund it with xDAI + BZZ on Gnosis (see the [Hoverfly README](https://github.com/omnipin/hoverfly#setup)), then buy a postage batch and generate an overlay nonce:
+
+```sh
+hoverfly batch create --key 0xYOUR_KEY --size 200MB --duration 30d
+hoverfly vanity-overlay --key 0xYOUR_KEY --peerlist peers.json --output overlay-nonce
+```
+
+### Running the daemon
+
+Start the daemon and leave it running:
+
+```sh
+hoverfly daemon \
+  --socket /tmp/hoverfly.sock \
+  --pool-size 256 \
+  --identity 0xYOUR_KEY \
+  --nonce-file overlay-nonce \
+  --peerlist peers.json
+```
+
+The repo ships a curated `peers.seed.json`; copy it to `peers.json` for a fast cold start (`cp peers.seed.json peers.json`). On a cold or stale peerlist, add `--discover-rounds 3`.
+
+### Running the deployment
+
+Set the postage batch ID and signer key in the environment:
+
+```sh
+OMNIPIN_HOVERFLY_TOKEN=0xf078...1afc # postage batch ID
+OMNIPIN_HOVERFLY_KEY=da25...0a44
+# OMNIPIN_HOVERFLY_SOCKET=/tmp/hoverfly.sock   # optional, this is the default
+```
+
+Then run the deployment command:
+
+```sh
+omnipin deploy
+```
+
+Omnipin reads the batch depth on-chain automatically; override it with `OMNIPIN_HOVERFLY_DEPTH` to skip the lookup. Other optional knobs: `OMNIPIN_HOVERFLY_RPC_URL`, `OMNIPIN_HOVERFLY_CONCURRENCY` (session fan-out, defaults to 256), and `OMNIPIN_HOVERFLY_RETRIES`.
 
 ## Swarmy
 
@@ -32,63 +87,6 @@ Then run the deployment command:
 ```sh
 omnipin deploy --ens omnipin.eth --safe eth:0x...
 ```
-
-## Hoverfly
-
-- API token env variables: `OMNIPIN_HOVERFLY_TOKEN`, `OMNIPIN_HOVERFLY_KEY`
-- Supported methods: Upload
-
-[Hoverfly](https://github.com/omnipin/hoverfly) is a minimal Swarm light client. Omnipin uploads through a locally-running `hoverfly daemon` over its UNIX socket — no Bee node and no remote API. The daemon holds a warm libp2p session pool, so each deploy is a single fast push instead of paying the cold connection-fill cost in-process.
-
-### Setup
-
-Install Hoverfly:
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/omnipin/hoverfly/main/install.sh | sh
-```
-
-Generate a signer key, fund it with xDAI + BZZ on Gnosis (see the [Hoverfly README](https://github.com/omnipin/hoverfly#setup)), then buy a postage batch and generate an overlay nonce directly with the CLI.
-
-Buy a postage stamp batch and generate an overlay nonce:
-
-```sh
-hoverfly batch create --key 0xYOUR_KEY --size 200MB --duration 30d
-hoverfly vanity-overlay --key 0xYOUR_KEY --peerlist peers.json --output overlay-nonce
-```
-
-### Running the daemon
-
-Start the daemon and leave it running. It picks up `peers.json` and the overlay nonce from the paths you pass, and keeps a warm session pool ready for uploads:
-
-```sh
-hoverfly daemon \
-  --socket /tmp/hoverfly.sock \
-  --pool-size 256 \
-  --identity 0xYOUR_KEY \
-  --nonce-file overlay-nonce \
-  --peerlist peers.json
-```
-
-The repo ships a curated `peers.seed.json`; copy it to `peers.json` for a fast cold start (`cp peers.seed.json peers.json`). On a cold or stale peerlist, add `--discover-rounds 3` so the eager pool fill has enough fresh peers to dial; a warm peerlist needs no discovery. The daemon persists reachability observations on shutdown, so subsequent starts are warmer.
-
-### Running the deployment
-
-Set the postage batch ID and signer key in the environment:
-
-```sh
-OMNIPIN_HOVERFLY_TOKEN=0xf078...1afc # postage batch ID
-OMNIPIN_HOVERFLY_KEY=da25...0a44
-# OMNIPIN_HOVERFLY_SOCKET=/tmp/hoverfly.sock   # optional, this is the default
-```
-
-Then run the deployment command:
-
-```sh
-omnipin deploy
-```
-
-Omnipin reads the batch depth on-chain automatically; override it with `OMNIPIN_HOVERFLY_DEPTH` to skip the lookup. Other optional knobs: `OMNIPIN_HOVERFLY_RPC_URL` (Gnosis RPC for the depth lookup), `OMNIPIN_HOVERFLY_CONCURRENCY` (session fan-out, defaults to 256 — raise toward `512` to push throughput on a large pool), and `OMNIPIN_HOVERFLY_RETRIES` (per-chunk retries, defaults to 60).
 
 ## Bee node
 

--- a/src/actions/deploy.ts
+++ b/src/actions/deploy.ts
@@ -83,6 +83,7 @@ export const deployAction = async ({
     cid: ipfsCid,
     bytes,
     size,
+    path: tarPath,
   } = await packAction({
     dir,
     options: {
@@ -129,6 +130,7 @@ export const deployAction = async ({
           beeURL: apiTokens.get('BEE_URL'),
           // Hoverfly talks to a local `hoverfly daemon` over its UNIX socket.
           key: apiTokens.get('HOVERFLY_KEY'),
+          path: tarPath,
           socket: apiTokens.get('HOVERFLY_SOCKET'),
           rpcUrl: apiTokens.get('HOVERFLY_RPC_URL'),
           depth: hoverflyDepth ? Number(hoverflyDepth) : undefined,

--- a/src/actions/deploy.ts
+++ b/src/actions/deploy.ts
@@ -117,6 +117,9 @@ export const deployAction = async ({
       bar?.update(total++, deployMessage(provider.name, provider.supported))
       const envVar = findEnvVarProviderName(provider.name)
       try {
+        const hoverflyDepth = apiTokens.get('HOVERFLY_DEPTH')
+        const hoverflyConcurrency = apiTokens.get('HOVERFLY_CONCURRENCY')
+        const hoverflyRetries = apiTokens.get('HOVERFLY_RETRIES')
         const result = await provider.upload({
           bytes,
           token: apiTokens.get(envVar)!,
@@ -124,6 +127,15 @@ export const deployAction = async ({
           name: '',
           first: true,
           beeURL: apiTokens.get('BEE_URL'),
+          // Hoverfly talks to a local `hoverfly daemon` over its UNIX socket.
+          key: apiTokens.get('HOVERFLY_KEY'),
+          socket: apiTokens.get('HOVERFLY_SOCKET'),
+          rpcUrl: apiTokens.get('HOVERFLY_RPC_URL'),
+          depth: hoverflyDepth ? Number(hoverflyDepth) : undefined,
+          concurrency: hoverflyConcurrency
+            ? Number(hoverflyConcurrency)
+            : undefined,
+          retries: hoverflyRetries ? Number(hoverflyRetries) : undefined,
         })
         swarmCid = result.cid
         cid = result.rID!

--- a/src/actions/pack.ts
+++ b/src/actions/pack.ts
@@ -57,7 +57,7 @@ export const packAction = async ({
       logger.info(`TAR: ${isTTY ? styleText('white', output) : output}`)
     }
 
-    return { name, bytes, files, size }
+    return { name, bytes, files, size, path: output }
   }
 
   const { rootCID, bytes } = await packCAR(files, name, dist)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,7 @@ import { pinOnQuicknode } from './providers/ipfs/quicknode.js'
 import { uploadToSimplePage } from './providers/ipfs/simplepage.js'
 import { specPin, specStatus, specUnpin } from './providers/ipfs/spec.js'
 import { uploadOnBee } from './providers/swarm/bee.js'
+import { uploadOnHoverfly } from './providers/swarm/hoverfly.js'
 import { uploadOnSwarmy } from './providers/swarm/swarmy.js'
 import type {
   StatusFunction,
@@ -137,6 +138,12 @@ export const PROVIDERS: Record<
   BEE_TOKEN: {
     name: 'Bee',
     upload: uploadOnBee,
+    supported: 'upload',
+    protocol: 'swarm',
+  },
+  HOVERFLY_TOKEN: {
+    name: 'Hoverfly',
+    upload: uploadOnHoverfly,
     supported: 'upload',
     protocol: 'swarm',
   },

--- a/src/providers/swarm/hoverfly.ts
+++ b/src/providers/swarm/hoverfly.ts
@@ -1,0 +1,138 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DeployError, PinningNotSupportedError } from '../../errors.js'
+import type { UploadFunction } from '../../types.js'
+import {
+  callDaemon,
+  DEFAULT_HOVERFLY_SOCKET,
+} from '../../utils/hoverfly-daemon.js'
+import { logger } from '../../utils/logger.js'
+import { referenceToCIDString, resolveBatchDepth } from '../../utils/swarm.js'
+
+const providerName = 'Hoverfly'
+
+/**
+ * Swarm upload via a running `hoverfly daemon` over its UNIX socket — no bee
+ * node, no remote API. The daemon holds a warm libp2p session pool and the node
+ * identity/overlay, so a single deploy is one fast framed request instead of
+ * paying the cold pool-fill + overlay-placement cost in-process.
+ *
+ * Start the daemon first (it picks up `peers.json` + `overlay-nonce` from its
+ * working dir; see hoverfly's README):
+ *
+ *   hoverfly daemon --socket /tmp/hoverfly.sock --pool-size 256 \
+ *     --identity 0xKEY --peerlist peers.json
+ *
+ * Then point omnipin at it with `OMNIPIN_HOVERFLY_TOKEN` (postage batch),
+ * `OMNIPIN_HOVERFLY_KEY` (signer), and optionally `OMNIPIN_HOVERFLY_SOCKET`.
+ */
+export const uploadOnHoverfly: UploadFunction<{
+  key?: string
+  socket?: string
+  rpcUrl?: string
+  depth?: number
+  concurrency?: number
+  retries?: number
+}> = async ({
+  token,
+  bytes,
+  verbose,
+  first,
+  key,
+  socket,
+  rpcUrl,
+  depth,
+  concurrency,
+  retries,
+}) => {
+  if (!first) throw new PinningNotSupportedError(providerName)
+  if (!key)
+    throw new DeployError(providerName, 'OMNIPIN_HOVERFLY_KEY is missing')
+
+  const socketPath = socket ?? DEFAULT_HOVERFLY_SOCKET
+  const batch = token.replace(/^0x/i, '')
+  const signer = key.replace(/^0x/i, '')
+
+  let tmpDir: string | undefined
+  try {
+    // Verify the daemon is up before doing any work.
+    const pong = await callDaemon(socketPath, { op: 'ping' }).catch(() => {
+      throw new DeployError(
+        providerName,
+        `no hoverfly daemon at ${socketPath} — start one with \`hoverfly daemon --socket ${socketPath} --identity 0x${signer} --peerlist peers.json\``,
+      )
+    })
+    if (pong.status !== 'pong') {
+      throw new DeployError(providerName, 'unexpected daemon ping response')
+    }
+
+    const batchDepth = depth ?? (await resolveBatchDepth(batch, rpcUrl))
+    if (verbose) logger.info(`${providerName}: batch depth ${batchDepth}`)
+
+    // The daemon reads the upload from a file path (client and daemon share a
+    // filesystem), so persist the packed TAR to a temp file. `.tar` +
+    // `collection: true` makes the daemon serve it as a browsable website.
+    tmpDir = await mkdtemp(join(tmpdir(), 'omnipin-hoverfly-'))
+    const tarPath = join(tmpDir, 'site.tar')
+    await writeFile(tarPath, bytes)
+
+    if (verbose) logger.info(`${providerName}: uploading via ${socketPath}…`)
+    // A large site can take minutes to push; the daemon streams progress to its
+    // own log, but the single socket response looks like a hang from here. Emit
+    // an elapsed-time heartbeat in verbose mode so it's clearly alive.
+    const startedAt = Date.now()
+    const heartbeat = verbose
+      ? setInterval(() => {
+          const secs = Math.round((Date.now() - startedAt) / 1000)
+          logger.info(`${providerName}: still uploading (${secs}s)…`)
+        }, 15_000)
+      : undefined
+    let resp: Awaited<ReturnType<typeof callDaemon>>
+    try {
+      resp = await callDaemon(socketPath, {
+        op: 'upload',
+        file: tarPath,
+        batch,
+        depth: batchDepth,
+        key: signer,
+        max_retries: retries ?? 60,
+        // The dispatcher fans out across this many sessions. The daemon's pool
+        // fills toward its --pool-size (e.g. 256), but a low request concurrency
+        // caps the live session set — hardcoding 8 left the pool stuck at
+        // `pool=8 eligible=0` on large uploads. Match the recommended pool size.
+        concurrency: concurrency ?? 256,
+        raw: false,
+        collection: true,
+        manifest_path: null,
+        content_type: null,
+        index_document: 'index.html',
+        error_document: 'index.html',
+      })
+    } finally {
+      if (heartbeat) clearInterval(heartbeat)
+    }
+
+    if (resp.status === 'err') {
+      throw new DeployError(providerName, resp.message)
+    }
+    if (resp.status !== 'uploaded') {
+      throw new DeployError(
+        providerName,
+        `unexpected daemon response: ${resp.status}`,
+      )
+    }
+
+    return {
+      cid: referenceToCIDString(`0x${resp.root}`),
+      rID: resp.root,
+    }
+  } catch (e) {
+    if (e instanceof PinningNotSupportedError || e instanceof DeployError)
+      throw e
+    throw new DeployError(providerName, (e as Error).message, { cause: e })
+  } finally {
+    if (tmpDir)
+      await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+  }
+}

--- a/src/providers/swarm/hoverfly.ts
+++ b/src/providers/swarm/hoverfly.ts
@@ -12,21 +12,6 @@ import { referenceToCIDString, resolveBatchDepth } from '../../utils/swarm.js'
 
 const providerName = 'Hoverfly'
 
-/**
- * Swarm upload via a running `hoverfly daemon` over its UNIX socket — no bee
- * node, no remote API. The daemon holds a warm libp2p session pool and the node
- * identity/overlay, so a single deploy is one fast framed request instead of
- * paying the cold pool-fill + overlay-placement cost in-process.
- *
- * Start the daemon first (it picks up `peers.json` + `overlay-nonce` from its
- * working dir; see hoverfly's README):
- *
- *   hoverfly daemon --socket /tmp/hoverfly.sock --pool-size 256 \
- *     --identity 0xKEY --peerlist peers.json
- *
- * Then point omnipin at it with `OMNIPIN_HOVERFLY_TOKEN` (postage batch),
- * `OMNIPIN_HOVERFLY_KEY` (signer), and optionally `OMNIPIN_HOVERFLY_SOCKET`.
- */
 export const uploadOnHoverfly: UploadFunction<{
   key?: string
   socket?: string
@@ -56,7 +41,6 @@ export const uploadOnHoverfly: UploadFunction<{
 
   let tmpDir: string | undefined
   try {
-    // Verify the daemon is up before doing any work.
     const pong = await callDaemon(socketPath, { op: 'ping' }).catch(() => {
       throw new DeployError(
         providerName,
@@ -70,17 +54,12 @@ export const uploadOnHoverfly: UploadFunction<{
     const batchDepth = depth ?? (await resolveBatchDepth(batch, rpcUrl))
     if (verbose) logger.info(`${providerName}: batch depth ${batchDepth}`)
 
-    // The daemon reads the upload from a file path (client and daemon share a
-    // filesystem), so persist the packed TAR to a temp file. `.tar` +
-    // `collection: true` makes the daemon serve it as a browsable website.
+    // The daemon reads the upload from a file path; persist the packed TAR.
     tmpDir = await mkdtemp(join(tmpdir(), 'omnipin-hoverfly-'))
     const tarPath = join(tmpDir, 'site.tar')
     await writeFile(tarPath, bytes)
 
     if (verbose) logger.info(`${providerName}: uploading via ${socketPath}…`)
-    // A large site can take minutes to push; the daemon streams progress to its
-    // own log, but the single socket response looks like a hang from here. Emit
-    // an elapsed-time heartbeat in verbose mode so it's clearly alive.
     const startedAt = Date.now()
     const heartbeat = verbose
       ? setInterval(() => {
@@ -97,10 +76,6 @@ export const uploadOnHoverfly: UploadFunction<{
         depth: batchDepth,
         key: signer,
         max_retries: retries ?? 60,
-        // The dispatcher fans out across this many sessions. The daemon's pool
-        // fills toward its --pool-size (e.g. 256), but a low request concurrency
-        // caps the live session set — hardcoding 8 left the pool stuck at
-        // `pool=8 eligible=0` on large uploads. Match the recommended pool size.
         concurrency: concurrency ?? 256,
         raw: false,
         collection: true,

--- a/src/providers/swarm/hoverfly.ts
+++ b/src/providers/swarm/hoverfly.ts
@@ -1,6 +1,3 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import { DeployError, PinningNotSupportedError } from '../../errors.js'
 import type { UploadFunction } from '../../types.js'
 import {
@@ -14,6 +11,7 @@ const providerName = 'Hoverfly'
 
 export const uploadOnHoverfly: UploadFunction<{
   key?: string
+  path?: string | null
   socket?: string
   rpcUrl?: string
   depth?: number
@@ -21,10 +19,10 @@ export const uploadOnHoverfly: UploadFunction<{
   retries?: number
 }> = async ({
   token,
-  bytes,
   verbose,
   first,
   key,
+  path,
   socket,
   rpcUrl,
   depth,
@@ -34,17 +32,19 @@ export const uploadOnHoverfly: UploadFunction<{
   if (!first) throw new PinningNotSupportedError(providerName)
   if (!key)
     throw new DeployError(providerName, 'OMNIPIN_HOVERFLY_KEY is missing')
+  // The daemon's upload op takes the packed `.tar` by path; `deploy` writes it
+  // via `packAction` and passes it through.
+  if (!path) throw new DeployError(providerName, 'missing packed TAR path')
 
   const socketPath = socket ?? DEFAULT_HOVERFLY_SOCKET
   const batch = token.replace(/^0x/i, '')
   const signer = key.replace(/^0x/i, '')
 
-  let tmpDir: string | undefined
   try {
     const pong = await callDaemon(socketPath, { op: 'ping' }).catch(() => {
       throw new DeployError(
         providerName,
-        `no hoverfly daemon at ${socketPath} — start one with \`hoverfly daemon --socket ${socketPath} --identity 0x${signer} --peerlist peers.json\``,
+        `no hoverfly daemon at ${socketPath} — start one with \`hoverfly daemon --socket ${socketPath}\``,
       )
     })
     if (pong.status !== 'pong') {
@@ -53,11 +53,6 @@ export const uploadOnHoverfly: UploadFunction<{
 
     const batchDepth = depth ?? (await resolveBatchDepth(batch, rpcUrl))
     if (verbose) logger.info(`${providerName}: batch depth ${batchDepth}`)
-
-    // The daemon reads the upload from a file path; persist the packed TAR.
-    tmpDir = await mkdtemp(join(tmpdir(), 'omnipin-hoverfly-'))
-    const tarPath = join(tmpDir, 'site.tar')
-    await writeFile(tarPath, bytes)
 
     if (verbose) logger.info(`${providerName}: uploading via ${socketPath}…`)
     const startedAt = Date.now()
@@ -71,7 +66,7 @@ export const uploadOnHoverfly: UploadFunction<{
     try {
       resp = await callDaemon(socketPath, {
         op: 'upload',
-        file: tarPath,
+        file: path,
         batch,
         depth: batchDepth,
         key: signer,
@@ -106,8 +101,5 @@ export const uploadOnHoverfly: UploadFunction<{
     if (e instanceof PinningNotSupportedError || e instanceof DeployError)
       throw e
     throw new DeployError(providerName, (e as Error).message, { cause: e })
-  } finally {
-    if (tmpDir)
-      await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
   }
 }

--- a/src/utils/hoverfly-daemon.ts
+++ b/src/utils/hoverfly-daemon.ts
@@ -1,0 +1,93 @@
+import net from 'node:net'
+
+/**
+ * Minimal client for the `hoverfly daemon` UNIX-socket IPC.
+ *
+ * Wire protocol (see hoverfly's src/daemon.rs): each request opens a fresh
+ * connection and exchanges exactly one framed message in each direction. A
+ * frame is a little-endian `u32` length prefix followed by a JSON body. The
+ * daemon owns the long-lived warm session pool and the node identity/overlay,
+ * so the client just hands it a request and reads the reply.
+ */
+
+/** `op`-tagged request union (serde `#[serde(tag = "op")]`). */
+export type HoverflyRequest =
+  | { op: 'ping' }
+  | {
+      op: 'upload'
+      file: string
+      batch: string
+      depth: number
+      key: string
+      max_retries: number
+      concurrency: number
+      raw: boolean
+      collection: boolean
+      manifest_path: string | null
+      content_type: string | null
+      index_document: string | null
+      error_document: string | null
+    }
+  | { op: 'reload_peers' }
+  | { op: 'save_peers' }
+  | { op: 'shutdown' }
+
+/** `status`-tagged response union (serde `#[serde(tag = "status")]`). */
+export type HoverflyResponse =
+  | { status: 'pong' }
+  | { status: 'uploaded'; root: string; bytes: number }
+  | { status: 'fetched'; bytes_written: number; content_type: string | null }
+  | { status: 'ok' }
+  | { status: 'err'; message: string }
+
+const MAX_FRAME = 1 << 20 // 1 MiB, matches the daemon's MAX_FRAME
+
+/**
+ * Send one request to the daemon at `socketPath` and resolve its response.
+ * Rejects if the socket is missing/unreachable (daemon not running) or the
+ * response frame is malformed.
+ */
+export const callDaemon = (
+  socketPath: string,
+  request: HoverflyRequest,
+): Promise<HoverflyResponse> =>
+  new Promise((resolve, reject) => {
+    const sock = net.createConnection({ path: socketPath })
+    const chunks: Buffer[] = []
+    let expected = -1
+
+    sock.on('connect', () => {
+      const body = Buffer.from(JSON.stringify(request), 'utf8')
+      const header = Buffer.allocUnsafe(4)
+      header.writeUInt32LE(body.length, 0)
+      sock.write(Buffer.concat([header, body]))
+    })
+
+    sock.on('data', (d: Buffer) => {
+      chunks.push(d)
+      const buf = Buffer.concat(chunks)
+      if (expected < 0 && buf.length >= 4) {
+        expected = buf.readUInt32LE(0)
+        if (expected > MAX_FRAME) {
+          sock.destroy()
+          reject(new Error(`daemon frame too large: ${expected}`))
+          return
+        }
+      }
+      if (expected >= 0 && buf.length >= 4 + expected) {
+        sock.end()
+        try {
+          resolve(JSON.parse(buf.subarray(4, 4 + expected).toString('utf8')))
+        } catch (e) {
+          reject(e as Error)
+        }
+      }
+    })
+
+    sock.on('error', reject)
+    sock.on('end', () => {
+      if (expected < 0) reject(new Error('daemon closed connection early'))
+    })
+  })
+
+export const DEFAULT_HOVERFLY_SOCKET = '/tmp/hoverfly.sock'

--- a/src/utils/hoverfly-daemon.ts
+++ b/src/utils/hoverfly-daemon.ts
@@ -1,16 +1,8 @@
 import net from 'node:net'
 
-/**
- * Minimal client for the `hoverfly daemon` UNIX-socket IPC.
- *
- * Wire protocol (see hoverfly's src/daemon.rs): each request opens a fresh
- * connection and exchanges exactly one framed message in each direction. A
- * frame is a little-endian `u32` length prefix followed by a JSON body. The
- * daemon owns the long-lived warm session pool and the node identity/overlay,
- * so the client just hands it a request and reads the reply.
- */
+// Client for the `hoverfly daemon` UNIX-socket IPC: one framed message
+// (u32-LE length prefix + JSON body) per direction, per connection.
 
-/** `op`-tagged request union (serde `#[serde(tag = "op")]`). */
 export type HoverflyRequest =
   | { op: 'ping' }
   | {
@@ -32,7 +24,6 @@ export type HoverflyRequest =
   | { op: 'save_peers' }
   | { op: 'shutdown' }
 
-/** `status`-tagged response union (serde `#[serde(tag = "status")]`). */
 export type HoverflyResponse =
   | { status: 'pong' }
   | { status: 'uploaded'; root: string; bytes: number }
@@ -40,13 +31,8 @@ export type HoverflyResponse =
   | { status: 'ok' }
   | { status: 'err'; message: string }
 
-const MAX_FRAME = 1 << 20 // 1 MiB, matches the daemon's MAX_FRAME
+const MAX_FRAME = 1 << 20
 
-/**
- * Send one request to the daemon at `socketPath` and resolve its response.
- * Rejects if the socket is missing/unreachable (daemon not running) or the
- * response frame is malformed.
- */
 export const callDaemon = (
   socketPath: string,
   request: HoverflyRequest,

--- a/src/utils/swarm.ts
+++ b/src/utils/swarm.ts
@@ -9,15 +9,9 @@ import * as varint from 'varint'
 const KECCAK_256_CODEC = 0x1b
 const SWARM_MANIFEST_CODEC = 0xfa
 
-/** Swarm-on-Gnosis mainnet `PostageStamp` contract. */
 const POSTAGE_STAMP_ADDRESS = '0x45a1502382541Cd610CC9068e88727426b696293'
 const DEFAULT_GNOSIS_RPC = 'https://rpc.gnosischain.com'
 
-/**
- * `PostageStamp.batches(bytes32)` public-mapping getter — returns the on-chain
- * Batch struct fields in storage order. We only need `depth`, but decode the
- * full tuple so the ABI matches.
- */
 const batchesAbi = {
   inputs: [{ name: 'id', type: 'bytes32' }],
   name: 'batches',
@@ -33,14 +27,7 @@ const batchesAbi = {
   type: 'function',
 } as const
 
-/**
- * Read a postage batch's depth from the on-chain `PostageStamp` contract via a
- * single `eth_call` (no gas, no tx). The WASM `uploadCollection` needs the
- * exact depth the batch was created with — the per-bucket stamp index math
- * diverges from what bee expects otherwise.
- *
- * @throws if the batch ID isn't registered on-chain (zero owner + zero depth).
- */
+/** Read a postage batch's depth from the on-chain `PostageStamp` contract. */
 export const resolveBatchDepth = async (
   batchIdHex: string,
   rpcUrl: string = DEFAULT_GNOSIS_RPC,

--- a/src/utils/swarm.ts
+++ b/src/utils/swarm.ts
@@ -1,10 +1,67 @@
 import { base32 } from 'multiformats/bases/base32'
 import { create } from 'multiformats/hashes/digest'
+import { decodeResult, encodeData } from 'ox/AbiFunction'
 import { type Hex, toBytes } from 'ox/Hex'
+import * as Provider from 'ox/Provider'
+import { fromHttp } from 'ox/RpcTransport'
 import * as varint from 'varint'
 
 const KECCAK_256_CODEC = 0x1b
 const SWARM_MANIFEST_CODEC = 0xfa
+
+/** Swarm-on-Gnosis mainnet `PostageStamp` contract. */
+const POSTAGE_STAMP_ADDRESS = '0x45a1502382541Cd610CC9068e88727426b696293'
+const DEFAULT_GNOSIS_RPC = 'https://rpc.gnosischain.com'
+
+/**
+ * `PostageStamp.batches(bytes32)` public-mapping getter — returns the on-chain
+ * Batch struct fields in storage order. We only need `depth`, but decode the
+ * full tuple so the ABI matches.
+ */
+const batchesAbi = {
+  inputs: [{ name: 'id', type: 'bytes32' }],
+  name: 'batches',
+  outputs: [
+    { name: 'owner', type: 'address' },
+    { name: 'depth', type: 'uint8' },
+    { name: 'bucketDepth', type: 'uint8' },
+    { name: 'immutableFlag', type: 'bool' },
+    { name: 'normalisedBalance', type: 'uint256' },
+    { name: 'lastUpdatedBlockNumber', type: 'uint256' },
+  ],
+  stateMutability: 'view',
+  type: 'function',
+} as const
+
+/**
+ * Read a postage batch's depth from the on-chain `PostageStamp` contract via a
+ * single `eth_call` (no gas, no tx). The WASM `uploadCollection` needs the
+ * exact depth the batch was created with — the per-bucket stamp index math
+ * diverges from what bee expects otherwise.
+ *
+ * @throws if the batch ID isn't registered on-chain (zero owner + zero depth).
+ */
+export const resolveBatchDepth = async (
+  batchIdHex: string,
+  rpcUrl: string = DEFAULT_GNOSIS_RPC,
+): Promise<number> => {
+  const id = `0x${batchIdHex.replace(/^0x/i, '')}` as Hex
+  const provider = Provider.from(fromHttp(rpcUrl))
+
+  const result = await provider.request({
+    method: 'eth_call',
+    params: [
+      { data: encodeData(batchesAbi, [id]), to: POSTAGE_STAMP_ADDRESS },
+      'latest',
+    ],
+  })
+
+  const [owner, depth] = decodeResult(batchesAbi, result)
+  if (owner === '0x0000000000000000000000000000000000000000' && depth === 0) {
+    throw new Error(`Postage batch ${id} not found on-chain`)
+  }
+  return Number(depth)
+}
 
 function encodeCID(
   version: 1,

--- a/test/providers/hoverfly.test.ts
+++ b/test/providers/hoverfly.test.ts
@@ -1,0 +1,83 @@
+/** biome-ignore-all lint/style/noNonNullAssertion: asserting env tokens */
+
+import { describe, expect, it } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { createTar } from 'nanotar'
+
+import { PROVIDERS } from '../../src/constants.js'
+import { PinningNotSupportedError } from '../../src/errors.js'
+import {
+  callDaemon,
+  DEFAULT_HOVERFLY_SOCKET,
+} from '../../src/utils/hoverfly-daemon.js'
+
+const { upload: uploadOnHoverfly } = PROVIDERS.HOVERFLY_TOKEN
+
+const socket = Bun.env.OMNIPIN_HOVERFLY_SOCKET ?? DEFAULT_HOVERFLY_SOCKET
+const key = Bun.env.OMNIPIN_HOVERFLY_KEY
+const batch = Bun.env.OMNIPIN_HOVERFLY_TOKEN
+const hasDaemon = existsSync(socket)
+const canUpload = hasDaemon && Boolean(key && batch)
+
+const tinyTar = (): Uint8Array<ArrayBuffer> =>
+  createTar([
+    { name: 'index.html', data: '<h1>omnipin × hoverfly daemon</h1>' },
+  ]) as Uint8Array<ArrayBuffer>
+
+describe('Hoverfly', () => {
+  it('throws PinningNotSupportedError when not the first provider', async () => {
+    await expect(
+      uploadOnHoverfly({
+        token: batch ?? '0x00',
+        bytes: tinyTar(),
+        name: '',
+        first: false,
+        size: 0,
+        cid: '',
+      }),
+    ).rejects.toThrow(PinningNotSupportedError)
+  })
+
+  it.skipIf(hasDaemon)(
+    'fails clearly when no daemon socket is present',
+    async () => {
+      await expect(
+        uploadOnHoverfly({
+          token: batch ?? '0x00',
+          key: key ?? '0xab',
+          socket: '/tmp/definitely-no-hoverfly.sock',
+          bytes: tinyTar(),
+          name: '',
+          first: true,
+          size: 0,
+          cid: '',
+        }),
+      ).rejects.toThrow(/no hoverfly daemon/)
+    },
+  )
+
+  it.skipIf(!hasDaemon)('pings a running daemon', async () => {
+    expect(await callDaemon(socket, { op: 'ping' })).toEqual({ status: 'pong' })
+  })
+
+  it.skipIf(!canUpload)(
+    'uploads a tiny collection through the daemon',
+    async () => {
+      const { cid, rID } = await uploadOnHoverfly({
+        token: batch!,
+        key: key!,
+        socket,
+        bytes: tinyTar(),
+        name: '',
+        first: true,
+        size: 0,
+        cid: '',
+        verbose: true,
+      })
+      expect(rID).toMatch(/^[0-9a-f]{64}$/i)
+      expect(cid).toMatch(/^[a-z2-7]+$/)
+      console.log(`Open: https://${cid}.bzz.limo/`)
+    },
+    { timeout: 120_000 },
+  )
+})

--- a/test/providers/hoverfly.test.ts
+++ b/test/providers/hoverfly.test.ts
@@ -2,6 +2,9 @@
 
 import { describe, expect, it } from 'bun:test'
 import { existsSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { createTar } from 'nanotar'
 
 import { PROVIDERS } from '../../src/constants.js'
@@ -19,17 +22,21 @@ const batch = Bun.env.OMNIPIN_HOVERFLY_TOKEN
 const hasDaemon = existsSync(socket)
 const canUpload = hasDaemon && Boolean(key && batch)
 
-const tinyTar = (): Uint8Array<ArrayBuffer> =>
-  createTar([
+const tinyTarPath = async (): Promise<string> => {
+  const bytes = createTar([
     { name: 'index.html', data: '<h1>omnipin × hoverfly daemon</h1>' },
-  ]) as Uint8Array<ArrayBuffer>
+  ]) as Uint8Array
+  const path = join(tmpdir(), `omnipin-hoverfly-test-${Date.now()}.tar`)
+  await writeFile(path, bytes)
+  return path
+}
 
 describe('Hoverfly', () => {
   it('throws PinningNotSupportedError when not the first provider', async () => {
     await expect(
       uploadOnHoverfly({
         token: batch ?? '0x00',
-        bytes: tinyTar(),
+        bytes: new Uint8Array() as Uint8Array<ArrayBuffer>,
         name: '',
         first: false,
         size: 0,
@@ -45,8 +52,9 @@ describe('Hoverfly', () => {
         uploadOnHoverfly({
           token: batch ?? '0x00',
           key: key ?? '0xab',
+          path: await tinyTarPath(),
           socket: '/tmp/definitely-no-hoverfly.sock',
-          bytes: tinyTar(),
+          bytes: new Uint8Array() as Uint8Array<ArrayBuffer>,
           name: '',
           first: true,
           size: 0,
@@ -66,8 +74,9 @@ describe('Hoverfly', () => {
       const { cid, rID } = await uploadOnHoverfly({
         token: batch!,
         key: key!,
+        path: await tinyTarPath(),
         socket,
-        bytes: tinyTar(),
+        bytes: new Uint8Array() as Uint8Array<ArrayBuffer>,
         name: '',
         first: true,
         size: 0,


### PR DESCRIPTION
Upload to Swarm through a local `hoverfly daemon` over its UNIX socket (u32-LE length + JSON framing) — no bee node, no remote API. Resolves batch depth on-chain from the Gnosis PostageStamp contract.

Env: OMNIPIN_HOVERFLY_TOKEN (batch), OMNIPIN_HOVERFLY_KEY (signer), optional _SOCKET/_DEPTH/_RPC_URL/_CONCURRENCY/_RETRIES.