### PR TITLE
fix(filecoin): poll SP for piece up to 5min instead of ~15s

### DIFF
--- a/src/providers/ipfs/filecoin.ts
+++ b/src/providers/ipfs/filecoin.ts
@@ -45,11 +45,34 @@ const providerName = 'Filecoin'
 async function findPiece(
   providerURL: string,
   pieceCid: string,
-  options: { retries?: number; pollInterval?: number; verbose?: boolean } = {},
+  options: {
+    timeoutMs?: number
+    pollInterval?: number
+    verbose?: boolean
+  } = {},
 ): Promise<void> {
-  const { retries = 5, pollInterval = 3000, verbose = false } = options
+  // This is an HTTP readiness probe against the SP's PDP server (`/pdp/piece`),
+  // NOT an on-chain wait — it polls until the SP has ingested and indexed the
+  // just-uploaded piece, before we move on to the on-chain addPieces step.
+  // Ingestion latency scales with payload size / SP load, so a small fixed
+  // retry count (previously 5 × 3s = ~15s) aborts otherwise-fine deploys.
+  //
+  // Mirror the upstream Synapse SDK (@filoz/synapse-core RETRY_CONSTANTS):
+  // poll every 4s, bounded by a 5-minute wall-clock timeout. Both are
+  // overridable via env for slow SPs / large payloads.
+  const envTimeout = Number(process.env.OMNIPIN_FILECOIN_FINDPIECE_TIMEOUT_MS)
+  const {
+    timeoutMs = Number.isFinite(envTimeout) && envTimeout > 0
+      ? envTimeout
+      : 1000 * 60 * 5,
+    pollInterval = 4000,
+    verbose = false,
+  } = options
 
-  for (let i = 0; i < retries; i++) {
+  const deadline = Date.now() + timeoutMs
+  let attempt = 0
+
+  while (Date.now() < deadline) {
     const res = await fetch(
       new URL(`/pdp/piece?pieceCid=${pieceCid}`, providerURL),
     )
@@ -58,12 +81,25 @@ async function findPiece(
     if (res.ok) {
       return
     }
+
+    attempt++
+    if (verbose && attempt % 5 === 0) {
+      const elapsed = Math.round((timeoutMs - (deadline - Date.now())) / 1000)
+      logger.info(
+        `Piece ${pieceCid} not yet stored at provider (${elapsed}s elapsed, ~${Math.round(
+          timeoutMs / 1000,
+        )}s budget); still waiting…`,
+      )
+    }
+
     await setTimeout(pollInterval)
   }
 
   throw new DeployError(
     providerName,
-    'Piece not found on provider after retries',
+    `Piece not found on provider after ~${Math.round(
+      timeoutMs / 1000,
+    )}s. The piece was uploaded but the SP did not confirm it in time; it may still settle. Retry the deploy, or raise OMNIPIN_FILECOIN_FINDPIECE_TIMEOUT_MS.`,
   )
 }
 


### PR DESCRIPTION
## Problem

A Filecoin deploy can fail with:

```
DeployError: Failed to deploy on Filecoin: Piece not found on provider after retries
    at findPiece (.../filecoin.ts)
```

…even though the piece **was** uploaded successfully and the deploy otherwise completed on the other providers.

`findPiece` is an HTTP readiness probe against the SP's PDP server (`GET /pdp/piece?pieceCid=…`). It confirms the SP has **ingested and indexed** the just-uploaded piece before we proceed to the on-chain `addPieces`/payment step. It is **not** an on-chain wait.

The previous budget was **5 retries × 3s ≈ 15s**. SP ingestion latency scales with payload size and SP load and routinely exceeds 15s, so deploys whose upload had already succeeded were aborted prematurely (before any payment tx, so nothing was charged).

## Fix

Mirror the upstream Synapse SDK (`@filoz/synapse-core` `RETRY_CONSTANTS`), which `SP.findPiece({ poll: true })` uses:

| | value |
|---|---|
| `POLL_INTERVAL` | `4000` (4s) |
| `POLL_LIMIT` | `Infinity` |
| `TIMEOUT` | `1000 * 60 * 5` (5 min) |

So `findPiece` now:
- polls every **4s** (was 3s),
- is bounded by a **5-minute wall-clock timeout** (was a fixed 5-retry count ≈ 15s),
- is overridable via `OMNIPIN_FILECOIN_FINDPIECE_TIMEOUT_MS` for slow SPs / large payloads,
- emits a clearer terminal error explaining the piece was uploaded and may still settle.

## Notes

- The option shape changed from `{ retries }` to `{ timeoutMs }`. Both call sites only pass `{ verbose }`, so they're unaffected.
- Behaviour is unchanged on the happy path (returns as soon as the SP reports the piece); this only widens the failure window.

## Test plan

- [x] `tsc --noEmit` clean for `filecoin.ts`
- [ ] Manual: `deploy` to a real SP with a payload large enough that ingestion exceeds 15s now succeeds instead of throwing `Piece not found`.

---
_Supersedes #187, which GitHub blocked from reopening after a branch force-push. Same branch, same single commit, now Biome-clean._
